### PR TITLE
fix: cross-platform command detection for Windows

### DIFF
--- a/setup/lib/prerequisites.mjs
+++ b/setup/lib/prerequisites.mjs
@@ -11,6 +11,14 @@ function commandExists(cmd) {
     execSync(`which ${cmd}`, { stdio: 'ignore' });
     return true;
   } catch {
+    if (process.platform === 'win32') {
+      try {
+        execSync(`where ${cmd}`, { stdio: 'ignore' });
+        return true;
+      } catch {
+        return false;
+      }
+    }
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- Fixes Windows detection of package managers (npm/pnpm) and other commands
- Uses `which` first, falls back to `where` on Windows
- Solves issue #113 where users on Windows get "No package manager found" error

## Test plan
- [ ] Test on Windows (Command Prompt, PowerShell, Git Bash)
- [ ] Test on macOS/Linux (should still work)

Generated with [Claude Code](https://claude.ai/code)