### PR TITLE
Fix Google provider ChatGoogleGenerativeAI constructor parameter

### DIFF
--- a/lib/ai/model.js
+++ b/lib/ai/model.js
@@ -62,7 +62,7 @@ export async function createModel(options = {}) {
         throw new Error('GOOGLE_API_KEY environment variable is required');
       }
       return new ChatGoogleGenerativeAI({
-        modelName,
+        model: modelName,
         maxOutputTokens: maxTokens,
         apiKey,
       });


### PR DESCRIPTION
Changed 'modelName' property to 'model' to match @langchain/google-genai v2.x API.

Fixes #132