### PR TITLE
fix: repair skills symlinks broken by Windows git + auto-activate brave-search (#156)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,6 +6,24 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { createDirLink } from '../setup/lib/fs-utils.mjs';
 
+/**
+ * Return true when `filePath` is a plain text file whose content exactly
+ * matches `expectedTarget`.  This is the artifact produced by Windows git
+ * (core.symlinks=false) when it checks out a mode-120000 symlink entry: the
+ * blob content (e.g. "../skills/active") is written as a regular file instead
+ * of creating an OS symlink.  Detecting this lets init() replace the text file
+ * with a real symlink rather than silently skipping symlink creation.
+ */
+function isTextFileSymlink(filePath, expectedTarget) {
+  try {
+    const stat = fs.lstatSync(filePath);
+    if (!stat.isFile()) return false; // directory, real symlink, etc.
+    return fs.readFileSync(filePath, 'utf8').trim() === expectedTarget;
+  } catch {
+    return false;
+  }
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -218,20 +236,35 @@ async function init() {
     }
   }
 
-  // Create default skill activation symlinks
+  // Create default skill activation symlinks.
+  // On Windows (git core.symlinks=false) the template symlinks land as plain
+  // text files whose content is the symlink target.  fs.existsSync() returns
+  // true for those files, which previously caused the symlink creation to be
+  // skipped silently — leaving the project without working symlinks and causing
+  // the Docker agent to crash at runtime.  isTextFileSymlink() detects this
+  // artifact and removes the text file so a real symlink can be created.
   const defaultSkills = ['browser-tools', 'llm-secrets', 'modify-self'];
   const activeDir = path.join(cwd, 'skills', 'active');
   fs.mkdirSync(activeDir, { recursive: true });
   for (const skill of defaultSkills) {
     const symlink = path.join(activeDir, skill);
+    const target = `../${skill}`;
+    if (isTextFileSymlink(symlink, target)) {
+      fs.unlinkSync(symlink);
+      console.log(`  Removed text-file artifact: skills/active/${skill}`);
+    }
     if (!fs.existsSync(symlink)) {
-      createDirLink(`../${skill}`, symlink);
-      console.log(`  Created skills/active/${skill} → ../${skill}`);
+      createDirLink(target, symlink);
+      console.log(`  Created skills/active/${skill} → ${target}`);
     }
   }
 
   // Create .pi/skills → ../skills/active symlink
   const piSkillsLink = path.join(cwd, '.pi', 'skills');
+  if (isTextFileSymlink(piSkillsLink, '../skills/active')) {
+    fs.unlinkSync(piSkillsLink);
+    console.log('  Removed text-file artifact: .pi/skills');
+  }
   if (!fs.existsSync(piSkillsLink)) {
     fs.mkdirSync(path.dirname(piSkillsLink), { recursive: true });
     createDirLink('../skills/active', piSkillsLink);
@@ -240,6 +273,10 @@ async function init() {
 
   // Create .claude/skills → ../skills/active symlink
   const claudeSkillsLink = path.join(cwd, '.claude', 'skills');
+  if (isTextFileSymlink(claudeSkillsLink, '../skills/active')) {
+    fs.unlinkSync(claudeSkillsLink);
+    console.log('  Removed text-file artifact: .claude/skills');
+  }
   if (!fs.existsSync(claudeSkillsLink)) {
     fs.mkdirSync(path.dirname(claudeSkillsLink), { recursive: true });
     createDirLink('../skills/active', claudeSkillsLink);

--- a/templates/docker/claude-code-job/entrypoint.sh
+++ b/templates/docker/claude-code-job/entrypoint.sh
@@ -41,6 +41,49 @@ fi
 
 cd /job
 
+# ── Repair skills directory structure ────────────────────────────────────────
+# On Windows hosts, git stores symlinks as plain text files containing the
+# target path (e.g. ".pi/skills" contains "../skills/active" as text).
+# This causes the agent to crash when it tries to use skills discovered via
+# .claude/skills. Detect and repair these artifacts so skills are always
+# discoverable regardless of the host OS that committed them.
+repair_dir_symlink() {
+    local link_path="$1"
+    local expected_target="$2"
+    if [ -f "$link_path" ] && [ ! -L "$link_path" ]; then
+        # Text file containing the symlink target — Windows git artifact
+        local stored
+        stored=$(cat "$link_path")
+        if [ "$stored" = "$expected_target" ]; then
+            rm "$link_path"
+            ln -sf "$expected_target" "$link_path"
+            echo "  Repaired symlink (was text file): $link_path → $expected_target"
+        fi
+    elif [ ! -e "$link_path" ] && [ ! -L "$link_path" ]; then
+        # Symlink is missing entirely — create it
+        mkdir -p "$(dirname "$link_path")"
+        ln -sf "$expected_target" "$link_path"
+        echo "  Created missing symlink: $link_path → $expected_target"
+    fi
+    # If it's already a valid symlink, leave it untouched
+}
+
+mkdir -p /job/skills/active
+repair_dir_symlink /job/.pi/skills     ../skills/active
+repair_dir_symlink /job/.claude/skills ../skills/active
+for skill in browser-tools llm-secrets modify-self; do
+    [ -d "/job/skills/$skill" ] && repair_dir_symlink "/job/skills/active/$skill" "../$skill"
+done
+
+# Auto-activate brave-search when BRAVE_API_KEY is present but the skill symlink
+# is missing. BRAVE_API_KEY reaches the container via the AGENT_BRAVE_API_KEY
+# GitHub secret (stripped to BRAVE_API_KEY by the SECRETS eval loop above).
+if [ -n "$BRAVE_API_KEY" ] && [ -d "/job/skills/brave-search" ] && [ ! -e "/job/skills/active/brave-search" ]; then
+    ln -sf ../brave-search /job/skills/active/brave-search
+    echo "  Auto-activated brave-search skill (BRAVE_API_KEY is set)"
+fi
+# ─────────────────────────────────────────────────────────────────────────────
+
 # Install npm deps for active skills (native deps need correct Linux arch)
 for skill_dir in /job/skills/active/*/; do
     if [ -f "${skill_dir}package.json" ]; then

--- a/templates/docker/pi-coding-agent-job/entrypoint.sh
+++ b/templates/docker/pi-coding-agent-job/entrypoint.sh
@@ -38,6 +38,49 @@ fi
 
 cd /job
 
+# ── Repair skills directory structure ────────────────────────────────────────
+# On Windows hosts, git stores symlinks as plain text files containing the
+# target path (e.g. ".pi/skills" contains "../skills/active" as text).
+# This causes the Pi agent to crash when it tries to create skill symlinks
+# inside what it expects to be a directory. Detect and repair these artifacts
+# so skills are always discoverable regardless of the host OS that committed them.
+repair_dir_symlink() {
+    local link_path="$1"
+    local expected_target="$2"
+    if [ -f "$link_path" ] && [ ! -L "$link_path" ]; then
+        # Text file containing the symlink target — Windows git artifact
+        local stored
+        stored=$(cat "$link_path")
+        if [ "$stored" = "$expected_target" ]; then
+            rm "$link_path"
+            ln -sf "$expected_target" "$link_path"
+            echo "  Repaired symlink (was text file): $link_path → $expected_target"
+        fi
+    elif [ ! -e "$link_path" ] && [ ! -L "$link_path" ]; then
+        # Symlink is missing entirely — create it
+        mkdir -p "$(dirname "$link_path")"
+        ln -sf "$expected_target" "$link_path"
+        echo "  Created missing symlink: $link_path → $expected_target"
+    fi
+    # If it's already a valid symlink, leave it untouched
+}
+
+mkdir -p /job/skills/active
+repair_dir_symlink /job/.pi/skills     ../skills/active
+repair_dir_symlink /job/.claude/skills ../skills/active
+for skill in browser-tools llm-secrets modify-self; do
+    [ -d "/job/skills/$skill" ] && repair_dir_symlink "/job/skills/active/$skill" "../$skill"
+done
+
+# Auto-activate brave-search when BRAVE_API_KEY is present but the skill symlink
+# is missing. BRAVE_API_KEY reaches the container via the AGENT_BRAVE_API_KEY
+# GitHub secret (stripped to BRAVE_API_KEY by the SECRETS eval loop above).
+if [ -n "$BRAVE_API_KEY" ] && [ -d "/job/skills/brave-search" ] && [ ! -e "/job/skills/active/brave-search" ]; then
+    ln -sf ../brave-search /job/skills/active/brave-search
+    echo "  Auto-activated brave-search skill (BRAVE_API_KEY is set)"
+fi
+# ─────────────────────────────────────────────────────────────────────────────
+
 # Install npm deps for active skills (native deps need correct Linux arch)
 for skill_dir in /job/skills/active/*/; do
     if [ -f "${skill_dir}package.json" ]; then


### PR DESCRIPTION
## Summary

Fixes #156 — *Agent does not use tools (Brave Search, Date Tool) despite configuration*

Two root causes identified and fixed:

- **Skills symlinks become text files on Windows git** (`core.symlinks=false`): git checks out mode-120000 symlink entries as plain text files. `bin/cli.js init()` copied these into the user's project, then the symlink-creation guard saw `fs.existsSync() === true` for the text file and silently skipped creating the real symlink. Those text files were committed as mode 100644. When the Docker agent cloned the repo on Linux, `.pi/skills` was a regular file — causing the Pi agent to crash: `ln: failed to create symbolic link '/job/.pi/skills/brave-search': No such file or directory`

- **`BRAVE_API_KEY` doesn't auto-activate brave-search**: Users set `AGENT_BRAVE_API_KEY` as a GitHub secret expecting the skill to work, but only the symlink `skills/active/brave-search` activates it. Without running the setup wizard, the symlink never gets created.

## Changes

### `bin/cli.js`
- Add `isTextFileSymlink(filePath, expectedTarget)` — uses `fs.lstatSync` to detect a text-file symlink artifact (Windows git) vs a real symlink or directory
- In `init()`, call `isTextFileSymlink` before each `createDirLink` call; remove the text-file artifact if found so the real symlink is always created

### `templates/docker/pi-coding-agent-job/entrypoint.sh`
### `templates/docker/claude-code-job/entrypoint.sh`
- Add `repair_dir_symlink` function: runs after `git clone`, detects text-file artifacts and replaces them with proper `ln -sf` symlinks; also creates any symlinks that are missing entirely
- Auto-activate `brave-search` skill when `BRAVE_API_KEY` is present in the environment but `skills/active/brave-search` symlink is absent (`BRAVE_API_KEY` is injected from `AGENT_BRAVE_API_KEY` GitHub secret via the existing SECRETS eval pipeline)

## Test Plan

- [x] `isTextFileSymlink` unit-tested across 6 cases: exact match, wrong content, directory, missing file, trailing newline, real symlink — all pass
- [x] Full `init()` flow simulated in Node.js: text-file artifacts replaced by real symlinks end-to-end
- [x] Bash syntax validated: `bash -n` passes on both entrypoints
- [x] `repair_dir_symlink` logic verified: only removes files whose content exactly matches the expected symlink target — unrelated files are left untouched
- [x] brave-search auto-activation: activates when key present, skips when key absent

## Backward Compatibility

- Projects already using proper symlinks (Linux/Mac init): `isTextFileSymlink` returns false → no change in behavior
- `repair_dir_symlink` in entrypoints: no-ops on valid symlinks (`[ -L ]` check passes, function returns immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)