### PR TITLE
fix: show helpful error when git identity is not configured on initia…

### DIFF
--- a/setup/setup.mjs
+++ b/setup/setup.mjs
@@ -158,8 +158,23 @@ async function main() {
     } catch {
       const commitSpinner = clack.spinner();
       commitSpinner.start('Creating initial commit...');
-      execSync('git commit -m "initial commit [skip ci]"', { stdio: 'ignore' });
-      commitSpinner.stop('Created initial commit');
+      try {
+        execSync('git commit -m "initial commit [skip ci]"', { stdio: 'pipe' });
+        commitSpinner.stop('Created initial commit');
+      } catch (commitErr) {
+        commitSpinner.stop('Commit failed');
+        const msg = commitErr.stderr?.toString() || commitErr.message || '';
+        if (msg.includes('Author identity unknown') || msg.includes('user.email') || msg.includes('user.name')) {
+          clack.log.error('Git user identity is not configured.');
+          clack.log.info('Run these commands then re-run setup:');
+          clack.log.info('  git config --global user.email "you@example.com"');
+          clack.log.info('  git config --global user.name "Your Name"');
+        } else {
+          clack.log.error(`Commit failed: ${msg.trim() || commitErr.message}`);
+        }
+        clack.cancel('Setup cancelled.');
+        process.exit(1);
+      }
     }
 
     // Ask for project name


### PR DESCRIPTION
fix: show helpful error when git identity is not configured on initial commit
Closes https://github.com/stephengpope/thepopebot/issues/178

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>