### PR TITLE
fix: chat delete broken in chats page and Safari sidebar

### DIFF
--- a/lib/chat/components/chats-page.jsx
+++ b/lib/chat/components/chats-page.jsx
@@ -322,6 +322,7 @@ function ChatRow({ chat, onNavigate, onDelete, onStar, onRename }) {
                   'text-muted-foreground hover:text-foreground hover:bg-muted'
                 )}
                 aria-label="Chat options"
+                onClick={(e) => e.stopPropagation()}
               >
                 <MoreHorizontalIcon size={14} />
               </button>

--- a/lib/chat/components/ui/confirm-dialog.jsx
+++ b/lib/chat/components/ui/confirm-dialog.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '../../utils.js';
 
 export function ConfirmDialog({ open, onConfirm, onCancel, title, description, confirmLabel = 'Delete', cancelLabel = 'Cancel', variant = 'destructive' }) {
@@ -23,7 +24,10 @@ export function ConfirmDialog({ open, onConfirm, onCancel, title, description, c
 
   if (!open) return null;
 
-  return (
+  // Render via portal so the overlay is always relative to the viewport, not a
+  // transformed ancestor (e.g. the sidebar in Safari ignores position:fixed when
+  // a parent has a CSS transform applied).
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="fixed inset-0 bg-black/50" onClick={onCancel} />
       <div className="relative z-50 w-full max-w-sm mx-4 rounded-lg border border-border bg-background p-6 shadow-lg" onClick={(e) => e.stopPropagation()}>
@@ -52,6 +56,7 @@ export function ConfirmDialog({ open, onConfirm, onCancel, title, description, c
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
Two bugs under #177:

1. chats-page.jsx: DropdownMenuTrigger button inside <a> row lacked stopPropagation, so clicking "..." triggered navigation to the chat before the dropdown could be used.

2. confirm-dialog.jsx: Render via createPortal to document.body so the overlay is always viewport-relative. Safari treats position:fixed as relative to any ancestor with a CSS transform (e.g. the animated sidebar), causing the dialog to appear clipped inside the sidebar.

Closes #177