### PR TITLE
feat: Add Z.AI (GLM) as first-class LLM provider

### DIFF
--- a/docs/RUNNING_DIFFERENT_MODELS.md
+++ b/docs/RUNNING_DIFFERENT_MODELS.md
@@ -17,12 +17,13 @@ Set these in your `.env` file:
 
 | Variable | Description |
 |----------|-------------|
-| `LLM_PROVIDER` | `anthropic` (default), `openai`, `google`, or `custom` |
-| `LLM_MODEL` | Model name (e.g. `claude-sonnet-4-20250514`, `gpt-4o`) — uses provider default if unset |
+| `LLM_PROVIDER` | `anthropic` (default), `openai`, `google`, `zai`, or `custom` |
+| `LLM_MODEL` | Model name (e.g. `claude-sonnet-4-20250514`, `gpt-4o`, `glm-4.7`) — uses provider default if unset |
 | `LLM_MAX_TOKENS` | Max tokens for responses (default: `4096`) |
 | `ANTHROPIC_API_KEY` | Required for `anthropic` provider |
 | `OPENAI_API_KEY` | Required for `openai` provider |
 | `GOOGLE_API_KEY` | Required for `google` provider |
+| `ZAI_API_KEY` | Required for `zai` provider (Z.AI / Zhipu AI) |
 | `CUSTOM_API_KEY` | Required for `custom` provider (if the endpoint needs auth) |
 | `OPENAI_BASE_URL` | Custom OpenAI-compatible base URL (for `custom` provider, e.g. `http://localhost:11434/v1`) |
 
@@ -78,6 +79,46 @@ npx thepopebot set-var RUNS_ON self-hosted
 
 Now your chat uses Claude while every job runs on the local Ollama instance.
 
+## Using Z.AI (GLM Models)
+
+Z.AI (Zhipu AI) provides the GLM family of models with excellent reasoning and coding capabilities. The API is OpenAI-compatible.
+
+### Event Handler with Z.AI
+
+Add to your `.env`:
+
+```bash
+LLM_PROVIDER=zai
+LLM_MODEL=glm-4.7
+ZAI_API_KEY=your-zai-api-key
+```
+
+### Jobs with Z.AI
+
+Set GitHub repo variables:
+
+```bash
+npx thepopebot set-var LLM_PROVIDER zai
+npx thepopebot set-var LLM_MODEL glm-4.7
+```
+
+Set the API key as a GitHub secret:
+
+```bash
+npx thepopebot set-agent-secret ZAI_API_KEY your-zai-api-key
+```
+
+### Available Z.AI Models
+
+| Model | Description |
+|-------|-------------|
+| `glm-4.7` | Flagship model with frontier reasoning and coding (recommended) |
+| `glm-4.6` | Balanced performance and speed |
+| `glm-4.5` | General purpose |
+| `glm-4.5-air` | Fast and lightweight |
+
+Get your API key at [https://z.ai/model-api](https://z.ai/model-api)
+
 ## Per-Job Overrides
 
 Add `llm_provider` and `llm_model` to any agent-type entry in `config/CRONS.json` or any action in `config/TRIGGERS.json`. This overrides the default for just that one job:
@@ -102,6 +143,7 @@ The matching API key must already exist as a GitHub secret (see the Providers ta
 | Provider | What it is | Example model | GitHub secret needed |
 |----------|------------|---------------|----------------------|
 | `anthropic` | Anthropic (default) | `claude-sonnet-4-20250514` | `AGENT_ANTHROPIC_API_KEY` |
+| `zai` | Z.AI / Zhipu GLM | `glm-4.7` | `AGENT_ZAI_API_KEY` |
 | `openai` | OpenAI | `gpt-4o` | `AGENT_OPENAI_API_KEY` |
 | `google` | Google Gemini | `gemini-2.5-pro` | `AGENT_GOOGLE_API_KEY` |
 | `custom` | Any OpenAI-compatible API (DeepSeek, Ollama, Together AI, etc.) | `deepseek-chat` | `AGENT_CUSTOM_API_KEY` *(if required — see below)* |

--- a/docs/ZAI_IMPLEMENTATION.md
+++ b/docs/ZAI_IMPLEMENTATION.md
@@ -1,0 +1,218 @@
+# Z.AI (GLM) Implementation Guide
+
+## Overview
+
+This document explains how Z.AI (Zhipu AI) was integrated into thepopebot as a first-class LLM provider. Use this guide if you want to implement similar providers or understand the architecture.
+
+## What is Z.AI?
+
+Z.AI (Zhipu AI) is a Chinese AI company providing the GLM (General Language Model) family. Their API is **OpenAI-compatible**, making integration straightforward.
+
+### Key Features
+- **OpenAI-compatible API** - Uses the same `/chat/completions` endpoint format
+- **Excellent reasoning and coding capabilities**
+- **Multiple model variants** - From flagship to fast/lightweight
+- **Competitive pricing**
+
+## Implementation Details
+
+### 1. Model Configuration (`lib/ai/model.js`)
+
+Added a new `zai` case in the `createModel()` switch statement:
+
+```javascript
+case 'zai': {
+  const { ChatOpenAI } = await import('@langchain/openai');
+  const apiKey = process.env.ZAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('ZAI_API_KEY environment variable is required for Z.AI provider');
+  }
+  return new ChatOpenAI({
+    modelName,
+    maxTokens,
+    apiKey,
+    configuration: {
+      baseURL: 'https://api.z.ai/v1',
+    },
+  });
+}
+```
+
+**Why ChatOpenAI?** Since Z.AI is OpenAI-compatible, we reuse LangChain's `ChatOpenAI` class with a custom `baseURL`.
+
+### 2. Default Model Mapping
+
+Added to `DEFAULT_MODELS`:
+
+```javascript
+const DEFAULT_MODELS = {
+  anthropic: 'claude-sonnet-4-20250514',
+  openai: 'gpt-4o',
+  google: 'gemini-2.5-pro',
+  zai: 'glm-4.7',  // <-- Added
+};
+```
+
+### 3. Provider Registry (`setup/lib/providers.mjs`)
+
+Added Z.AI to the `PROVIDERS` export:
+
+```javascript
+zai: {
+  label: 'GLM (Z.AI / Zhipu)',
+  name: 'Z.AI',
+  envKey: 'ZAI_API_KEY',
+  keyPrefix: '',
+  keyPage: 'https://z.ai/model-api',
+  builtin: false,
+  baseUrl: 'https://api.z.ai/v1',
+  api: 'openai-completions',
+  models: [
+    { id: 'glm-4.7', name: 'GLM-4.7 (Flagship)', default: true },
+    { id: 'glm-4.6', name: 'GLM-4.6' },
+    { id: 'glm-4.5', name: 'GLM-4.5' },
+    { id: 'glm-4.5-air', name: 'GLM-4.5 Air (Fast)' },
+  ],
+},
+```
+
+### 4. Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `LLM_PROVIDER=zai` | Selects Z.AI as the provider |
+| `LLM_MODEL=glm-4.7` | (Optional) Model name, defaults to `glm-4.7` |
+| `ZAI_API_KEY` | Your Z.AI API key |
+
+## How to Add a New OpenAI-Compatible Provider
+
+Use this checklist to add any OpenAI-compatible provider:
+
+### Step 1: Add to `lib/ai/model.js`
+
+1. Add default model to `DEFAULT_MODELS`
+2. Add a new case in `createModel()` switch:
+   ```javascript
+   case 'your-provider': {
+     const { ChatOpenAI } = await import('@langchain/openai');
+     const apiKey = process.env.YOUR_PROVIDER_API_KEY;
+     if (!apiKey) {
+       throw new Error('YOUR_PROVIDER_API_KEY environment variable is required');
+     }
+     return new ChatOpenAI({
+       modelName,
+       maxTokens,
+       apiKey,
+       configuration: {
+         baseURL: 'https://api.your-provider.com/v1',
+       },
+     });
+   }
+   ```
+
+### Step 2: Add to `setup/lib/providers.mjs`
+
+```javascript
+your-provider: {
+  label: 'Your Provider Name',
+  name: 'YourProvider',
+  envKey: 'YOUR_PROVIDER_API_KEY',
+  keyPrefix: '',
+  keyPage: 'https://your-provider.com/keys',
+  builtin: false,
+  baseUrl: 'https://api.your-provider.com/v1',
+  api: 'openai-completions',
+  models: [
+    { id: 'model-1', name: 'Model 1', default: true },
+    { id: 'model-2', name: 'Model 2' },
+  ],
+},
+```
+
+### Step 3: Update Documentation
+
+Add your provider to `docs/RUNNING_DIFFERENT_MODELS.md`:
+1. Add to the environment variables table
+2. Add to the providers table
+3. Add a usage section if needed
+
+### Step 4: Test
+
+```bash
+# Event Handler test
+LLM_PROVIDER=your-provider \
+YOUR_PROVIDER_API_KEY=your-key \
+node -e "import('./lib/ai/model.js').then(m => m.createModel().then(r => console.log('Success:', r)))"
+
+# Job test (GitHub Actions)
+npx thepopebot set-var LLM_PROVIDER your-provider
+npx thepopebot set-var LLM_MODEL model-1
+npx thepopebot set-agent-secret YOUR_PROVIDER_API_KEY your-key
+```
+
+## API Endpoint Details
+
+### Z.AI API
+- **Base URL**: `https://api.z.ai/v1`
+- **Chat Endpoint**: `/chat/completions`
+- **Auth Header**: `Authorization: Bearer YOUR_API_KEY`
+- **Format**: OpenAI-compatible JSON
+
+### Example Request
+
+```bash
+curl https://api.z.ai/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "glm-4.7",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+## Available Models
+
+| Model ID | Description | Best For |
+|----------|-------------|----------|
+| `glm-4.7` | Flagship model | Complex reasoning, coding, agents |
+| `glm-4.6` | Balanced | General purpose |
+| `glm-4.5` | Standard | Everyday tasks |
+| `glm-4.5-air` | Fast & lightweight | Quick responses, high throughput |
+
+## Getting an API Key
+
+1. Visit [https://z.ai/model-api](https://z.ai/model-api)
+2. Sign up or log in
+3. Generate an API key from the dashboard
+4. Add to your `.env` file or GitHub secrets
+
+## Alternative: Using Custom Provider
+
+If you don't want to modify the code, you can use the `custom` provider:
+
+```bash
+# Event Handler
+LLM_PROVIDER=custom
+LLM_MODEL=glm-4.7
+OPENAI_BASE_URL=https://api.z.ai/v1
+CUSTOM_API_KEY=your-zai-api-key
+```
+
+```bash
+# Jobs
+npx thepopebot set-var LLM_PROVIDER custom
+npx thepopebot set-var LLM_MODEL glm-4.7
+npx thepopebot set-var OPENAI_BASE_URL https://api.z.ai/v1
+npx thepopebot set-agent-secret CUSTOM_API_KEY your-zai-api-key
+```
+
+This works immediately without code changes but won't appear in the setup wizard.
+
+## Summary
+
+Z.AI integration required:
+1. **~15 lines** in `lib/ai/model.js` (provider case)
+2. **~12 lines** in `setup/lib/providers.mjs` (registry entry)
+3. **Documentation updates** in `docs/RUNNING_DIFFERENT_MODELS.md`
+
+The key insight is that any OpenAI-compatible API can be integrated with minimal code by reusing `ChatOpenAI` with a custom `baseURL`.

--- a/lib/ai/model.js
+++ b/lib/ai/model.js
@@ -4,18 +4,21 @@ const DEFAULT_MODELS = {
   anthropic: 'claude-sonnet-4-20250514',
   openai: 'gpt-4o',
   google: 'gemini-2.5-pro',
+  zai: 'glm-4.7',
 };
 
 /**
  * Create a LangChain chat model based on environment configuration.
  *
  * Config env vars:
- *   LLM_PROVIDER    — "anthropic" (default), "openai", "google"
+ *   LLM_PROVIDER    — "anthropic" (default), "openai", "google", "zai", "custom"
  *   LLM_MODEL       — Model name override (e.g. "claude-sonnet-4-20250514")
  *   ANTHROPIC_API_KEY — Required for anthropic provider
  *   OPENAI_API_KEY   — Required for openai provider (optional with OPENAI_BASE_URL)
  *   OPENAI_BASE_URL  — Custom OpenAI-compatible base URL (e.g. http://localhost:11434/v1 for Ollama)
  *   GOOGLE_API_KEY   — Required for google provider
+ *   ZAI_API_KEY      — Required for zai provider (Z.AI / Zhipu AI)
+ *   CUSTOM_API_KEY   — Required for custom provider (if the endpoint needs auth)
  *
  * @param {object} [options]
  * @param {number} [options.maxTokens=4096] - Max tokens for the response
@@ -36,6 +39,21 @@ export async function createModel(options = {}) {
         modelName,
         maxTokens,
         anthropicApiKey: apiKey,
+      });
+    }
+    case 'zai': {
+      const { ChatOpenAI } = await import('@langchain/openai');
+      const apiKey = process.env.ZAI_API_KEY;
+      if (!apiKey) {
+        throw new Error('ZAI_API_KEY environment variable is required for Z.AI provider');
+      }
+      return new ChatOpenAI({
+        modelName,
+        maxTokens,
+        apiKey,
+        configuration: {
+          baseURL: 'https://api.z.ai/v1',
+        },
       });
     }
     case 'custom':

--- a/setup/lib/providers.mjs
+++ b/setup/lib/providers.mjs
@@ -19,6 +19,22 @@ export const PROVIDERS = {
       { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5' },
     ],
   },
+  zai: {
+    label: 'GLM (Z.AI / Zhipu)',
+    name: 'Z.AI',
+    envKey: 'ZAI_API_KEY',
+    keyPrefix: '',
+    keyPage: 'https://z.ai/model-api',
+    builtin: false,
+    baseUrl: 'https://api.z.ai/v1',
+    api: 'openai-completions',
+    models: [
+      { id: 'glm-4.7', name: 'GLM-4.7 (Flagship)', default: true },
+      { id: 'glm-4.6', name: 'GLM-4.6' },
+      { id: 'glm-4.5', name: 'GLM-4.5' },
+      { id: 'glm-4.5-air', name: 'GLM-4.5 Air (Fast)' },
+    ],
+  },
   openai: {
     label: 'GPT (OpenAI)',
     name: 'OpenAI',


### PR DESCRIPTION
## Summary

This PR adds **Z.AI (Zhipu AI)** as a first-class LLM provider, enabling users to easily use GLM models (GLM-4.7, GLM-4.6, GLM-4.5, etc.) in thepopebot.

## Changes

### 1. `lib/ai/model.js`
- Added `zai` to `DEFAULT_MODELS` with `glm-4.7` as default
- Added `zai` case in `createModel()` using OpenAI-compatible API
- Uses endpoint `https://api.z.ai/v1`

### 2. `setup/lib/providers.mjs`
- Added Z.AI to the `PROVIDERS` registry
- Includes model list: GLM-4.7, GLM-4.6, GLM-4.5, GLM-4.5 Air
- Links to API key page: https://z.ai/model-api

### 3. `docs/RUNNING_DIFFERENT_MODELS.md`
- Updated environment variables table to include `ZAI_API_KEY`
- Added Z.AI to providers table
- Added dedicated Using Z.AI (GLM Models) section with examples

### 4. `docs/ZAI_IMPLEMENTATION.md` (NEW)
- Comprehensive guide on how Z.AI was integrated
- Step-by-step instructions for adding new OpenAI-compatible providers
- API endpoint details and model information

## Usage

### Event Handler (`.env`)
```bash
LLM_PROVIDER=zai
LLM_MODEL=glm-4.7
ZAI_API_KEY=your-api-key
```

### Jobs (GitHub repo variables)
```bash
npx thepopebot set-var LLM_PROVIDER zai
npx thepopebot set-var LLM_MODEL glm-4.7
npx thepopebot set-agent-secret ZAI_API_KEY your-api-key
```

## Why Z.AI?

Z.AI provides the GLM family of models with:
- Excellent reasoning and coding capabilities
- OpenAI-compatible API (easy integration)
- Competitive pricing
- Multiple model variants (flagship to fast/lightweight)

## Testing

- [ ] Test Event Handler with Z.AI provider
- [ ] Test Job execution with Z.AI provider
- [ ] Verify setup wizard shows Z.AI option

## Implementation Details

See `docs/ZAI_IMPLEMENTATION.md` for a detailed guide on how this integration works and how to add similar OpenAI-compatible providers.