### PR TITLE
feat: reorder sidebar — Clusters above Chats (#193)

### DIFF
--- a/lib/chat/components/app-sidebar.jsx
+++ b/lib/chat/components/app-sidebar.jsx
@@ -103,24 +103,6 @@ export function AppSidebar({ user }) {
       {!collapsed && (
         <SidebarContent>
           <SidebarMenu>
-            {/* Chats history */}
-            <SidebarMenuItem>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <SidebarMenuButton
-                    href="/chats"
-                    className={collapsed ? 'justify-center' : ''}
-                  >
-                    <MessageIcon size={16} />
-                    {!collapsed && <span>Chats</span>}
-                  </SidebarMenuButton>
-                </TooltipTrigger>
-                {collapsed && (
-                  <TooltipContent side="right">Chats</TooltipContent>
-                )}
-              </Tooltip>
-            </SidebarMenuItem>
-
             {/* Clusters */}
             <SidebarMenuItem>
               <Tooltip>
@@ -135,6 +117,24 @@ export function AppSidebar({ user }) {
                 </TooltipTrigger>
                 {collapsed && (
                   <TooltipContent side="right">Clusters</TooltipContent>
+                )}
+              </Tooltip>
+            </SidebarMenuItem>
+
+            {/* Chats history */}
+            <SidebarMenuItem>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <SidebarMenuButton
+                    href="/chats"
+                    className={collapsed ? 'justify-center' : ''}
+                  >
+                    <MessageIcon size={16} />
+                    {!collapsed && <span>Chats</span>}
+                  </SidebarMenuButton>
+                </TooltipTrigger>
+                {collapsed && (
+                  <TooltipContent side="right">Chats</TooltipContent>
                 )}
               </Tooltip>
             </SidebarMenuItem>


### PR DESCRIPTION
## Summary

- Moves the **Clusters** sidebar menu item above **Chats**, making it the first nav item
- No logic, icon, route, label, or badge changes — purely a visual reorder
- Resolves #193

## Changes

**File:** `lib/chat/components/app-sidebar.jsx`

New nav order:
1. Clusters (`/clusters`) ← moved up
2. Chats (`/chats`) ← moved down
3. Runners (`/runners`)
4. Approvals (`/pull-requests`)
5. Notifications (`/notifications`)
6. Upgrade *(conditional)*
7. Support

## Rationale

Clusters is the foundational concept — users set up clusters before chats exist. Surfacing it first reflects the natural mental model: configure infrastructure → run work through it.

## Test plan

- [ ] Open sidebar in expanded state: verify Clusters appears above Chats
- [ ] Open sidebar in collapsed (icon-only) state: verify ClusterIcon appears above MessageIcon
- [ ] Confirm tooltip labels are still correct for both items
- [ ] Confirm remaining items (Runners, Approvals, Notifications) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)