### PR TITLE
feat(sidebar): swap Clusters and Chats menu order (#198)

### DIFF
--- a/lib/chat/components/app-sidebar.jsx
+++ b/lib/chat/components/app-sidebar.jsx
@@ -103,24 +103,6 @@ export function AppSidebar({ user }) {
       {!collapsed && (
         <SidebarContent>
           <SidebarMenu>
-            {/* Chats history */}
-            <SidebarMenuItem>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <SidebarMenuButton
-                    href="/chats"
-                    className={collapsed ? 'justify-center' : ''}
-                  >
-                    <MessageIcon size={16} />
-                    {!collapsed && <span>Chats</span>}
-                  </SidebarMenuButton>
-                </TooltipTrigger>
-                {collapsed && (
-                  <TooltipContent side="right">Chats</TooltipContent>
-                )}
-              </Tooltip>
-            </SidebarMenuItem>
-
             {/* Clusters */}
             <SidebarMenuItem>
               <Tooltip>
@@ -135,6 +117,24 @@ export function AppSidebar({ user }) {
                 </TooltipTrigger>
                 {collapsed && (
                   <TooltipContent side="right">Clusters</TooltipContent>
+                )}
+              </Tooltip>
+            </SidebarMenuItem>
+
+            {/* Chats history */}
+            <SidebarMenuItem>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <SidebarMenuButton
+                    href="/chats"
+                    className={collapsed ? 'justify-center' : ''}
+                  >
+                    <MessageIcon size={16} />
+                    {!collapsed && <span>Chats</span>}
+                  </SidebarMenuButton>
+                </TooltipTrigger>
+                {collapsed && (
+                  <TooltipContent side="right">Chats</TooltipContent>
                 )}
               </Tooltip>
             </SidebarMenuItem>


### PR DESCRIPTION
## Summary

Fixes #198 — reorders the sidebar navigation so **Clusters** appears above **Chats**, improving discoverability for the primary navigation entry point.

**Changes:**
- Swapped the `<SidebarMenuItem>` blocks for "Clusters" (`/clusters`) and "Chats" (`/chats`) in `lib/chat/components/app-sidebar.jsx`
- Ran `npm run build` to regenerate the compiled `app-sidebar.js` ES module output

**Sidebar order after this PR:**
1. New chat *(header)*
2. **Clusters** → `/clusters` *(moved up)*
3. **Chats** → `/chats` *(moved down)*
4. Runners → `/runners`
5. Approvals → `/pull-requests`
6. Notifications → `/notifications`
7. Upgrade *(conditional)*
8. Support *(external)*

## Test plan

- [ ] Expanded sidebar: Clusters appears above Chats
- [ ] Clicking Clusters navigates to `/clusters`
- [ ] Clicking Chats navigates to `/chats`
- [ ] No regression on other menu items (Runners, Approvals, Notifications, Upgrade, Support)
- [ ] Mobile view: order consistent with desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)