### PR TITLE
feat: multiple named API keys in /settings/secrets

### DIFF
--- a/lib/chat/actions.js
+++ b/lib/chat/actions.js
@@ -222,14 +222,19 @@ export async function triggerUpgrade() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Create (or replace) the API key.
+ * Create a new named API key.
+ * @param {string} name - Display name (non-empty, max 64 chars)
  * @returns {Promise<{ key: string, record: object } | { error: string }>}
  */
-export async function createNewApiKey() {
+export async function createNewApiKey(name) {
   const user = await requireAuth();
+  if (!name || typeof name !== 'string') return { error: 'Name is required' };
+  const trimmed = name.trim();
+  if (!trimmed) return { error: 'Name is required' };
+  if (trimmed.length > 64) return { error: 'Name must be 64 characters or fewer' };
   try {
     const { createApiKeyRecord } = await import('../db/api-keys.js');
-    return createApiKeyRecord(user.id);
+    return createApiKeyRecord(user.id, trimmed);
   } catch (err) {
     console.error('Failed to create API key:', err);
     return { error: 'Failed to create API key' };
@@ -237,29 +242,31 @@ export async function createNewApiKey() {
 }
 
 /**
- * Get the current API key metadata (no hash).
- * @returns {Promise<object|null>}
+ * Get all API keys metadata (no hashes).
+ * @returns {Promise<object[]>}
  */
 export async function getApiKeys() {
   await requireAuth();
   try {
-    const { getApiKey } = await import('../db/api-keys.js');
-    return getApiKey();
+    const { getApiKeys: dbGetApiKeys } = await import('../db/api-keys.js');
+    return dbGetApiKeys();
   } catch (err) {
-    console.error('Failed to get API key:', err);
-    return null;
+    console.error('Failed to get API keys:', err);
+    return [];
   }
 }
 
 /**
- * Delete the API key.
+ * Delete an API key by its UUID.
+ * @param {string} id - UUID of the key to delete
  * @returns {Promise<{ success: boolean } | { error: string }>}
  */
-export async function deleteApiKey() {
+export async function deleteApiKey(id) {
   await requireAuth();
+  if (!id || typeof id !== 'string') return { error: 'Invalid key ID' };
   try {
-    const mod = await import('../db/api-keys.js');
-    mod.deleteApiKey();
+    const { deleteApiKeyById } = await import('../db/api-keys.js');
+    deleteApiKeyById(id);
     return { success: true };
   } catch (err) {
     console.error('Failed to delete API key:', err);

--- a/lib/chat/components/settings-secrets-page.jsx
+++ b/lib/chat/components/settings-secrets-page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { KeyIcon, CopyIcon, CheckIcon, TrashIcon, RefreshIcon } from './icons.js';
+import { useState, useEffect, useRef } from 'react';
+import { KeyIcon, CopyIcon, CheckIcon, TrashIcon } from './icons.js';
 import { createNewApiKey, getApiKeys, deleteApiKey } from '../actions.js';
 
 function timeAgo(ts) {
@@ -75,76 +75,99 @@ function Section({ title, description, children }) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// API Key section
+// API Keys section
 // ─────────────────────────────────────────────────────────────────────────────
 
 function ApiKeySection() {
-  const [currentKey, setCurrentKey] = useState(null);
+  const [keys, setKeys] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [nameInput, setNameInput] = useState('');
+  const [formError, setFormError] = useState(null);
   const [creating, setCreating] = useState(false);
   const [newKey, setNewKey] = useState(null);
-  const [confirmDelete, setConfirmDelete] = useState(false);
-  const [confirmRegenerate, setConfirmRegenerate] = useState(false);
-  const [error, setError] = useState(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState(null);
+  const confirmTimerRef = useRef(null);
+  const nameInputRef = useRef(null);
 
-  const loadKey = async () => {
+  const loadKeys = async () => {
     try {
       const result = await getApiKeys();
-      setCurrentKey(result);
+      setKeys(Array.isArray(result) ? result : []);
     } catch {
-      // ignore
+      setKeys([]);
     } finally {
       setLoading(false);
     }
   };
 
   useEffect(() => {
-    loadKey();
+    loadKeys();
   }, []);
 
-  const handleCreate = async () => {
+  // Auto-focus name input when form opens
+  useEffect(() => {
+    if (showForm && nameInputRef.current) {
+      nameInputRef.current.focus();
+    }
+  }, [showForm]);
+
+  const handleOpenForm = () => {
+    setShowForm(true);
+    setNameInput('');
+    setFormError(null);
+  };
+
+  const handleCancelForm = () => {
+    setShowForm(false);
+    setNameInput('');
+    setFormError(null);
+  };
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
     if (creating) return;
+    const trimmed = nameInput.trim();
+    if (!trimmed) {
+      setFormError('Name is required');
+      return;
+    }
     setCreating(true);
-    setError(null);
-    setConfirmRegenerate(false);
+    setFormError(null);
     try {
-      const result = await createNewApiKey();
+      const result = await createNewApiKey(trimmed);
       if (result.error) {
-        setError(result.error);
+        setFormError(result.error);
       } else {
         setNewKey(result.key);
-        await loadKey();
+        setShowForm(false);
+        setNameInput('');
+        await loadKeys();
       }
     } catch {
-      setError('Failed to create API key');
+      setFormError('Failed to create API key');
     } finally {
       setCreating(false);
     }
   };
 
-  const handleDelete = async () => {
-    if (!confirmDelete) {
-      setConfirmDelete(true);
-      setTimeout(() => setConfirmDelete(false), 3000);
+  const handleDelete = async (id) => {
+    if (confirmDeleteId !== id) {
+      if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+      setConfirmDeleteId(id);
+      confirmTimerRef.current = setTimeout(() => setConfirmDeleteId(null), 3000);
       return;
     }
+    setConfirmDeleteId(null);
     try {
-      await deleteApiKey();
-      setCurrentKey(null);
-      setNewKey(null);
-      setConfirmDelete(false);
+      await deleteApiKey(id);
+      setKeys((prev) => prev.filter((k) => k.id !== id));
+      if (newKey && keys.find((k) => k.id === id)) {
+        setNewKey(null);
+      }
     } catch {
       // ignore
     }
-  };
-
-  const handleRegenerate = () => {
-    if (!confirmRegenerate) {
-      setConfirmRegenerate(true);
-      setTimeout(() => setConfirmRegenerate(false), 3000);
-      return;
-    }
-    handleCreate();
   };
 
   if (loading) {
@@ -153,8 +176,56 @@ function ApiKeySection() {
 
   return (
     <div>
-      {error && (
-        <p className="text-sm text-destructive mb-4">{error}</p>
+      {/* Header row: section action button */}
+      <div className="flex justify-end mb-3">
+        <button
+          onClick={handleOpenForm}
+          disabled={showForm}
+          className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium border border-border bg-background text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50 disabled:pointer-events-none"
+        >
+          + Add API key
+        </button>
+      </div>
+
+      {/* Inline create form */}
+      {showForm && (
+        <form
+          onSubmit={handleCreate}
+          className="rounded-lg border bg-card p-4 mb-3"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+            <div className="flex-1">
+              <input
+                ref={nameInputRef}
+                type="text"
+                value={nameInput}
+                onChange={(e) => setNameInput(e.target.value)}
+                placeholder="e.g. production"
+                maxLength={64}
+                className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+              {formError && (
+                <p className="mt-1.5 text-xs text-destructive">{formError}</p>
+              )}
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <button
+                type="submit"
+                disabled={creating || !nameInput.trim()}
+                className="inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium bg-foreground text-background hover:bg-foreground/90 disabled:opacity-50 disabled:pointer-events-none"
+              >
+                {creating ? 'Creating...' : 'Create'}
+              </button>
+              <button
+                type="button"
+                onClick={handleCancelForm}
+                className="text-xs text-muted-foreground hover:text-foreground"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </form>
       )}
 
       {/* New key banner */}
@@ -180,60 +251,50 @@ function ApiKeySection() {
         </div>
       )}
 
-      {currentKey ? (
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-3">
-              <div className="shrink-0 rounded-md bg-muted p-2">
-                <KeyIcon size={16} />
+      {/* Key list */}
+      {keys.length > 0 ? (
+        <div className="rounded-lg border bg-card divide-y divide-border">
+          {keys.map((apiKey) => (
+            <div
+              key={apiKey.id}
+              className="flex flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="flex items-center gap-3">
+                <div className="shrink-0 rounded-md bg-muted p-2">
+                  <KeyIcon size={16} />
+                </div>
+                <div>
+                  <p className="text-sm font-medium">{apiKey.name}</p>
+                  <div className="flex flex-wrap items-center gap-x-2 mt-0.5">
+                    <code className="text-xs font-mono text-muted-foreground truncate max-w-[160px]">
+                      {apiKey.keyPrefix}...
+                    </code>
+                    <span className="text-xs text-muted-foreground">
+                      Created {formatDate(apiKey.createdAt)}
+                      {apiKey.lastUsedAt
+                        ? ` · Last used ${timeAgo(apiKey.lastUsedAt)}`
+                        : ' · Never used'}
+                    </span>
+                  </div>
+                </div>
               </div>
-              <div>
-                <code className="text-sm font-mono">{currentKey.keyPrefix}...</code>
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  Created {formatDate(currentKey.createdAt)}
-                  {currentKey.lastUsedAt && (
-                    <span className="ml-2">· Last used {timeAgo(currentKey.lastUsedAt)}</span>
-                  )}
-                </p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2 shrink-0">
               <button
-                onClick={handleRegenerate}
-                disabled={creating}
-                className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium border ${
-                  confirmRegenerate
-                    ? 'border-yellow-500 text-yellow-600 hover:bg-yellow-500/10'
-                    : 'border-border text-muted-foreground hover:bg-accent hover:text-foreground'
-                } disabled:opacity-50`}
-              >
-                <RefreshIcon size={12} />
-                {creating ? 'Generating...' : confirmRegenerate ? 'Confirm regenerate' : 'Regenerate'}
-              </button>
-              <button
-                onClick={handleDelete}
-                className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium border ${
-                  confirmDelete
+                onClick={() => handleDelete(apiKey.id)}
+                className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium border min-h-[32px] min-w-[64px] shrink-0 ${
+                  confirmDeleteId === apiKey.id
                     ? 'border-destructive text-destructive hover:bg-destructive/10'
                     : 'border-border text-muted-foreground hover:text-destructive hover:border-destructive/50'
                 }`}
               >
                 <TrashIcon size={12} />
-                {confirmDelete ? 'Confirm delete' : 'Delete'}
+                {confirmDeleteId === apiKey.id ? 'Confirm delete' : 'Delete'}
               </button>
             </div>
-          </div>
+          ))}
         </div>
       ) : (
-        <div className="rounded-lg border border-dashed bg-card p-6 flex flex-col items-center text-center">
-          <p className="text-sm text-muted-foreground mb-3">No API key configured</p>
-          <button
-            onClick={handleCreate}
-            disabled={creating}
-            className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium bg-foreground text-background hover:bg-foreground/90 disabled:opacity-50 disabled:pointer-events-none"
-          >
-            {creating ? 'Creating...' : 'Create API key'}
-          </button>
+        <div className="rounded-lg border border-dashed bg-card p-6 flex items-center justify-center">
+          <p className="text-sm text-muted-foreground">No API keys — add one above</p>
         </div>
       )}
     </div>
@@ -248,7 +309,7 @@ export function SettingsSecretsPage() {
   return (
     <div>
       <Section
-        title="API Key"
+        title="API Keys"
         description="Authenticates external requests to /api endpoints. Pass via the x-api-key header."
       >
         <ApiKeySection />

--- a/lib/db/api-keys.js
+++ b/lib/db/api-keys.js
@@ -5,7 +5,7 @@ import { settings } from './schema.js';
 
 const KEY_PREFIX = 'tpb_';
 
-// In-memory cache: { key_hash, id } or null
+// In-memory cache: Map<keyHash, {id, name}> or null (not loaded)
 let _cache = null;
 
 /**
@@ -26,23 +26,23 @@ export function hashApiKey(key) {
 }
 
 /**
- * Lazy-load the API key hash into the in-memory cache.
+ * Lazy-load all API key hashes into the in-memory cache Map.
+ * @returns {Map<string, {id: string, name: string}>}
  */
 function _ensureCache() {
   if (_cache !== null) return _cache;
 
   const db = getDb();
-  const row = db
+  const rows = db
     .select()
     .from(settings)
     .where(eq(settings.type, 'api_key'))
-    .get();
+    .all();
 
-  if (row) {
+  _cache = new Map();
+  for (const row of rows) {
     const parsed = JSON.parse(row.value);
-    _cache = { keyHash: parsed.key_hash, id: row.id };
-  } else {
-    _cache = false; // no key exists — distinguish from "not loaded yet"
+    _cache.set(parsed.key_hash, { id: row.id, name: row.key });
   }
   return _cache;
 }
@@ -55,15 +55,13 @@ export function invalidateApiKeyCache() {
 }
 
 /**
- * Create (or replace) the API key. Deletes any existing key first.
+ * Create a new named API key. Does NOT delete existing keys.
  * @param {string} createdBy - User ID
+ * @param {string} name - Display name for the key (stored in settings.key column)
  * @returns {{ key: string, record: object }}
  */
-export function createApiKeyRecord(createdBy) {
+export function createApiKeyRecord(createdBy, name) {
   const db = getDb();
-
-  // Delete any existing API key
-  db.delete(settings).where(eq(settings.type, 'api_key')).run();
 
   const key = generateApiKey();
   const keyHash = hashApiKey(key);
@@ -73,7 +71,7 @@ export function createApiKeyRecord(createdBy) {
   const record = {
     id: randomUUID(),
     type: 'api_key',
-    key: 'api_key',
+    key: name,
     value: JSON.stringify({ key_prefix: keyPrefix, key_hash: keyHash, last_used_at: null }),
     createdBy,
     createdAt: now,
@@ -87,6 +85,7 @@ export function createApiKeyRecord(createdBy) {
     key,
     record: {
       id: record.id,
+      name,
       keyPrefix,
       createdAt: now,
       lastUsedAt: null,
@@ -95,39 +94,43 @@ export function createApiKeyRecord(createdBy) {
 }
 
 /**
- * Get the current API key metadata (no hash).
- * @returns {object|null}
+ * Get all API keys metadata (no hashes).
+ * Existing keys stored with key='api_key' are returned with name='api_key'.
+ * @returns {object[]}
  */
-export function getApiKey() {
+export function getApiKeys() {
   const db = getDb();
-  const row = db
+  const rows = db
     .select()
     .from(settings)
     .where(eq(settings.type, 'api_key'))
-    .get();
+    .all();
 
-  if (!row) return null;
-
-  const parsed = JSON.parse(row.value);
-  return {
-    id: row.id,
-    keyPrefix: parsed.key_prefix,
-    createdAt: row.createdAt,
-    lastUsedAt: parsed.last_used_at,
-  };
+  return rows.map((row) => {
+    const parsed = JSON.parse(row.value);
+    return {
+      id: row.id,
+      name: row.key,
+      keyPrefix: parsed.key_prefix,
+      createdAt: row.createdAt,
+      lastUsedAt: parsed.last_used_at,
+    };
+  });
 }
 
 /**
- * Delete the API key.
+ * Delete an API key by its UUID primary key.
+ * @param {string} id - UUID of the settings row
  */
-export function deleteApiKey() {
+export function deleteApiKeyById(id) {
   const db = getDb();
-  db.delete(settings).where(eq(settings.type, 'api_key')).run();
+  db.delete(settings).where(eq(settings.id, id)).run();
   invalidateApiKeyCache();
 }
 
 /**
- * Verify a raw API key against the cached hash.
+ * Verify a raw API key against the cached hash Map.
+ * Timing-safe comparison applied per entry.
  * @param {string} rawKey - Raw API key from request header
  * @returns {object|null} Record if valid, null otherwise
  */
@@ -135,29 +138,33 @@ export function verifyApiKey(rawKey) {
   if (!rawKey || !rawKey.startsWith(KEY_PREFIX)) return null;
 
   const keyHash = hashApiKey(rawKey);
-  const cached = _ensureCache();
+  const cache = _ensureCache();
 
-  if (!cached) return null;
-  const a = Buffer.from(cached.keyHash, 'hex');
-  const b = Buffer.from(keyHash, 'hex');
-  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  if (cache.size === 0) return null;
 
-  // Update last_used_at in background (non-blocking)
-  try {
-    const db = getDb();
-    const now = Date.now();
-    const row = db.select().from(settings).where(eq(settings.id, cached.id)).get();
-    if (row) {
-      const parsed = JSON.parse(row.value);
-      parsed.last_used_at = now;
-      db.update(settings)
-        .set({ value: JSON.stringify(parsed), updatedAt: now })
-        .where(eq(settings.id, cached.id))
-        .run();
+  const a = Buffer.from(keyHash, 'hex');
+  for (const [storedHash, entry] of cache) {
+    const b = Buffer.from(storedHash, 'hex');
+    if (a.length === b.length && timingSafeEqual(a, b)) {
+      // Update last_used_at in background (non-blocking)
+      try {
+        const db = getDb();
+        const now = Date.now();
+        const row = db.select().from(settings).where(eq(settings.id, entry.id)).get();
+        if (row) {
+          const parsed = JSON.parse(row.value);
+          parsed.last_used_at = now;
+          db.update(settings)
+            .set({ value: JSON.stringify(parsed), updatedAt: now })
+            .where(eq(settings.id, entry.id))
+            .run();
+        }
+      } catch {
+        // Non-fatal: last_used_at is informational
+      }
+      return entry;
     }
-  } catch {
-    // Non-fatal: last_used_at is informational
   }
 
-  return cached;
+  return null;
 }


### PR DESCRIPTION
Closes #197

## Summary

- **DB layer** (`lib/db/api-keys.js`): In-memory cache changed from a single entry to a `Map<keyHash, {id, name}>`. `createApiKeyRecord(createdBy, name)` accepts a name and no longer deletes existing keys. `getApiKeys()` returns an array of all keys. `deleteApiKeyById(id)` deletes by UUID. `verifyApiKey` iterates the Map with per-entry timing-safe comparison. Backward-compatible: existing `key='api_key'` rows appear in the list with name `'api_key'`.

- **Server actions** (`lib/chat/actions.js`): `createNewApiKey(name)` validates name server-side (non-empty, max 64 chars). `getApiKeys()` calls the renamed DB function and returns an array. `deleteApiKey(id)` accepts a UUID and calls `deleteApiKeyById`.

- **UI** (`lib/chat/components/settings-secrets-page.jsx`): `ApiKeySection` rewritten as a key manager. Persistent "Add API key" button at top of section. Inline create form with auto-focused name input, client+server validation, loading/error states. Key list with per-row confirm-before-delete (3s timeout, only the clicked row enters confirm state). Empty state dashed card. One-time key banner unchanged. Regenerate button removed — users create a new key then delete the old one.

## Test plan

- [ ] Create a key with a name — appears in list with correct prefix, created date, never-used label
- [ ] Create a second key with a different name — both appear in the list
- [ ] Both keys authenticate `x-api-key` requests to `/api`
- [ ] Delete one key — removed from list, remaining key still authenticates
- [ ] Confirm-before-delete: first click shows "Confirm delete" (red), second click within 3s deletes; timeout resets
- [ ] Existing single key (legacy `key='api_key'` row) appears with name `'api_key'` and authenticates normally
- [ ] Name validation: empty name blocked client-side and server-side; name > 64 chars rejected server-side
- [ ] "Cancel" on create form collapses without creating a key

🤖 Generated with [Claude Code](https://claude.com/claude-code)