### PR TITLE
fix: auto-replace unsupported Gemini thinking models (#188)

### DIFF
--- a/lib/ai/CLAUDE.md
+++ b/lib/ai/CLAUDE.md
@@ -30,10 +30,12 @@ Two agent types, both using `createReactAgent` from `@langchain/langgraph/prebui
 |----------|----------------|---------------|-------------|
 | Anthropic | `anthropic` (default) | `claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` |
 | OpenAI | `openai` | `gpt-4o` | `OPENAI_API_KEY` |
-| Google | `google` | `gemini-2.5-pro` | `GOOGLE_API_KEY` |
+| Google | `google` | `gemini-2.5-flash` | `GOOGLE_API_KEY` |
 | Custom | `custom` | — | `OPENAI_BASE_URL`, `CUSTOM_API_KEY` (optional) |
 
 `LLM_MAX_TOKENS` defaults to 4096. Web search available for `anthropic` and `openai` providers only (disable with `WEB_SEARCH=false`).
+
+> **Google model compatibility note:** `gemini-2.5-pro` and all `gemini-3.*` models require `thought_signature` round-tripping that `@langchain/google-genai` does not yet support. Setting `LLM_MODEL` to one of these will automatically fall back to `gemini-2.5-flash` at runtime with a warning. Supported Gemini models: `gemini-2.5-flash` (default), `gemini-2.5-flash-lite`. Full support for thinking models is tracked in issue #201.
 
 ## Chat Streaming
 

--- a/lib/ai/model.js
+++ b/lib/ai/model.js
@@ -3,8 +3,13 @@ import { ChatAnthropic } from '@langchain/anthropic';
 const DEFAULT_MODELS = {
   anthropic: 'claude-sonnet-4-20250514',
   openai: 'gpt-4o',
-  google: 'gemini-2.5-pro',
+  google: 'gemini-2.5-flash',
 };
+
+// These models require thought_signature round-tripping which @langchain/google-genai doesn't support.
+// Auto-replace with gemini-2.5-flash until we migrate to @langchain/google (see issue #201).
+const GEMINI_UNSUPPORTED_MODELS = ['gemini-2.5-pro', 'gemini-3'];
+const GEMINI_FALLBACK = 'gemini-2.5-flash';
 
 /**
  * Create a LangChain chat model based on environment configuration.
@@ -61,8 +66,17 @@ export async function createModel(options = {}) {
       if (!apiKey) {
         throw new Error('GOOGLE_API_KEY environment variable is required');
       }
+      let resolvedModel = modelName;
+      const isUnsupported = GEMINI_UNSUPPORTED_MODELS.some(m => resolvedModel.startsWith(m));
+      if (isUnsupported) {
+        console.warn(
+          `[model] ${resolvedModel} requires thought_signature support not yet available in @langchain/google-genai. ` +
+          `Falling back to ${GEMINI_FALLBACK}. See https://github.com/stephengpope/thepopebot/issues/201.`
+        );
+        resolvedModel = GEMINI_FALLBACK;
+      }
       return new ChatGoogleGenerativeAI({
-        model: modelName,
+        model: resolvedModel,
         maxOutputTokens: maxTokens,
         apiKey,
       });


### PR DESCRIPTION
## Summary

- Changes default Google model from `gemini-2.5-pro` to `gemini-2.5-flash` in `lib/ai/model.js`
- Adds runtime auto-replacement: if `LLM_MODEL` is set to `gemini-2.5-pro` or any `gemini-3.*` model (which require `thought_signature` round-tripping unsupported by `@langchain/google-genai`), the model is silently replaced with `gemini-2.5-flash` and a `console.warn` is emitted
- Updates `lib/ai/CLAUDE.md` provider table to show `gemini-2.5-flash` as the new default and documents the unsupported model list

## Root Cause

This is a LangChain JS bug — Gemini 2.5 Pro and 3.x thinking models return a `thought_signature` field that must be echoed back in multi-turn calls. `@langchain/google-genai` does not preserve this across LangGraph `SqliteSaver` checkpointer turns, causing the Gemini API to reject subsequent requests.

## Test plan

- [ ] Set `LLM_PROVIDER=google` with no `LLM_MODEL` — confirm `gemini-2.5-flash` is used
- [ ] Set `LLM_MODEL=gemini-2.5-pro` — confirm warning is logged and `gemini-2.5-flash` is used instead
- [ ] Set `LLM_MODEL=gemini-3.0-pro` — confirm warning is logged and `gemini-2.5-flash` is used instead
- [ ] Set `LLM_MODEL=gemini-2.5-flash` — confirm no warning, model used as-is
- [ ] Set `LLM_MODEL=gemini-2.5-flash-lite` — confirm no warning, model used as-is
- [ ] Multi-turn tool-call conversations with `gemini-2.5-flash` complete without API errors

Closes #188. Long-term migration to `@langchain/google` tracked in #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)