### PR TITLE
fix: create log directory before running agent container (#168)

### DIFF
--- a/templates/.github/workflows/run-job.yml
+++ b/templates/.github/workflows/run-job.yml
@@ -47,6 +47,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare log directory
+        run: |
+          JOB_ID="${{ github.ref_name }}"
+          JOB_ID="${JOB_ID#job/}"
+          mkdir -p "logs/${JOB_ID}"
+
       - name: Run thepopebot Agent
         env:
           ALL_SECRETS: ${{ toJson(secrets) }}


### PR DESCRIPTION
Fixes #168

## Problem
The `run-job.yml` workflow fails because the Docker container expects a `logs/{JOB_ID}` directory to exist on the host volume, but the workflow never creates it. This causes:
`Error: ENOENT: no such file or directory, open 'logs/.../stdout.log'`

## Fix
Add a "Prepare log directory" step before the Docker run step that creates the required directory:
```bash
JOB_ID="${GITHUB_REF_NAME#job/}"
mkdir -p "logs/${JOB_ID}"
```

This ensures the directory exists before the agent container tries to write logs to it.