### PR TITLE
fix: support pasting images from clipboard in chat (#209)

### DIFF
--- a/lib/chat/components/chat-input.jsx
+++ b/lib/chat/components/chat-input.jsx
@@ -111,6 +111,19 @@ export function ChatInput({ input, setInput, onSubmit, status, stop, files, setF
     }
   };
 
+  const handlePaste = useCallback((e) => {
+    if (!e.clipboardData?.items) return;
+    const imageItems = Array.from(e.clipboardData.items).filter(
+      (item) => item.type.startsWith('image/')
+    );
+    if (imageItems.length === 0) return;
+    e.preventDefault();
+    const imageFiles = imageItems.map((item) => item.getAsFile()).filter(Boolean);
+    if (imageFiles.length > 0) {
+      handleFiles(imageFiles);
+    }
+  }, [handleFiles]);
+
   const handleDragOver = (e) => {
     e.preventDefault();
     setIsDragging(true);
@@ -202,6 +215,7 @@ export function ChatInput({ input, setInput, onSubmit, status, stop, files, setF
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             placeholder={placeholder}
             rows={1}
             className={cn(


### PR DESCRIPTION
## Summary

Fixes #209 — Copy and Pasting Images from Clipboard Does Not Work

## Problem

When a user copies an image (e.g. a screenshot via Cmd+Shift+4 or Ctrl+PrtSc) and presses Ctrl+V / Cmd+V in the chat textarea, nothing happened. The chat input had no `onPaste` handler to intercept clipboard image data.

## Solution

Added a `handlePaste` callback to `lib/chat/components/chat-input.jsx` that:

1. Checks `e.clipboardData.items` for any items with an `image/*` MIME type
2. If image items are found, calls `e.preventDefault()` to suppress default browser paste behavior
3. Converts each image item to a `File` object via `item.getAsFile()`
4. Passes the files to the existing `handleFiles` helper — the same path used by the file picker and drag-and-drop — so images appear in the attachment preview strip before sending

No new dependencies. The fix is minimal and consistent with the existing file attachment flow.

## Testing

- Take a screenshot / copy any image to clipboard
- Open the chat input and press Cmd+V / Ctrl+V
- Image should appear in the attachment preview strip, ready to send