### PR TITLE
feat: add latest model versions (Claude 4.6, GPT-5 Mini, Gemini 3.1)

### DIFF
--- a/lib/ai/CLAUDE.md
+++ b/lib/ai/CLAUDE.md
@@ -28,7 +28,7 @@ Two agent types, both using `createReactAgent` from `@langchain/langgraph/prebui
 
 | Provider | `LLM_PROVIDER` | Default Model | Required Env |
 |----------|----------------|---------------|-------------|
-| Anthropic | `anthropic` (default) | `claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` |
+| Anthropic | `anthropic` (default) | `claude-sonnet-4-6-20250514` | `ANTHROPIC_API_KEY` |
 | OpenAI | `openai` | `gpt-4o` | `OPENAI_API_KEY` |
 | Google | `google` | `gemini-2.5-flash` | `GOOGLE_API_KEY` |
 | Custom | `custom` | — | `OPENAI_BASE_URL`, `CUSTOM_API_KEY` (optional) |

--- a/lib/llm-providers.js
+++ b/lib/llm-providers.js
@@ -17,7 +17,9 @@ export const BUILTIN_PROVIDERS = {
       },
     ],
     models: [
-      { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4', default: true },
+      { id: 'claude-sonnet-4-6-20250514', name: 'Claude Sonnet 4.6', default: true },
+      { id: 'claude-opus-4-6-20250514', name: 'Claude Opus 4.6' },
+      { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4' },
       { id: 'claude-opus-4-20250514', name: 'Claude Opus 4' },
       { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5' },
     ],
@@ -32,6 +34,7 @@ export const BUILTIN_PROVIDERS = {
       { id: 'gpt-4o-mini', name: 'GPT-4o Mini' },
       { id: 'o3', name: 'o3' },
       { id: 'o4-mini', name: 'o4-mini' },
+      { id: 'gpt-5-mini', name: 'GPT-5 Mini' },
     ],
   },
   google: {
@@ -42,6 +45,7 @@ export const BUILTIN_PROVIDERS = {
     models: [
       { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', default: true },
       { id: 'gemini-2.5-flash-lite', name: 'Gemini 2.5 Flash Lite' },
+      { id: 'gemini-3.1-flash-lite-preview', name: 'Gemini 3.1 Flash Lite Preview' },
     ],
   },
 };


### PR DESCRIPTION
## Summary

- **Anthropic**: Add Claude Sonnet 4.6 and Opus 4.6, set Sonnet 4.6 as new default
- **OpenAI**: Add GPT-5 Mini
- **Google**: Add Gemini 3.1 Flash Lite Preview
- All existing models preserved for backward compatibility

## Test plan

- [x] Tested on live deployment (bot.markenetica.com) with custom Docker image
- [x] Verified new models appear in settings dropdown
- [x] Confirmed all new models work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)