### PR TITLE
fix: restore chat input focus after response completes

### DIFF
--- a/lib/chat/components/chat-input.jsx
+++ b/lib/chat/components/chat-input.jsx
@@ -76,6 +76,14 @@ export function ChatInput({ input, setInput, onSubmit, status, stop, files, setF
     textareaRef.current?.focus();
   }, []);
 
+  // Refocus textarea after streaming completes (layout swap causes focus loss)
+  useEffect(() => {
+    if (!isStreaming && !disabled) {
+      const timer = setTimeout(() => textareaRef.current?.focus(), 100);
+      return () => clearTimeout(timer);
+    }
+  }, [isStreaming, disabled]);
+
   const handleFiles = useCallback((fileList) => {
     const newFiles = Array.from(fileList).filter(isAcceptedType);
     if (newFiles.length === 0) return;


### PR DESCRIPTION
## Summary

- Textarea loses focus when the AI finishes streaming because the Chat component swaps between a loading layout and the full ChatInput at different DOM positions
- Adds a `useEffect` that re-focuses the textarea 100ms after streaming ends, giving the layout swap time to settle

## Test plan

- [x] Send a message and verify the textarea regains focus after the response completes
- [x] Verify focus is not stolen during streaming
- [x] Verify Shift+Enter still works for newlines

Tested on live deployment at bot.markenetica.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)