### PR TITLE
fix: detect missing git identity and show actionable error in setup

### DIFF
--- a/setup/setup.mjs
+++ b/setup/setup.mjs
@@ -146,7 +146,10 @@ async function main() {
   }
 
   // Set git identity from GitHub if not configured
-  try { execSync('git config user.name', { stdio: 'ignore' }); } catch {
+  try {
+    execSync('git config user.name', { stdio: 'ignore' });
+    execSync('git config user.email', { stdio: 'ignore' });
+  } catch {
     try {
       const ghUser = JSON.parse(execSync('gh api user', { encoding: 'utf-8', env: ghEnv() }));
       execSync(`git config --global user.name "${ghUser.name || ghUser.login}"`, { stdio: 'ignore' });
@@ -178,8 +181,22 @@ async function main() {
     } catch {
       const commitSpinner = clack.spinner();
       commitSpinner.start('Creating initial commit...');
-      execSync('git commit -m "initial commit [skip ci]"', { stdio: 'ignore' });
-      commitSpinner.stop('Created initial commit');
+      try {
+        execSync('git commit -m "initial commit [skip ci]"', { stdio: 'ignore' });
+        commitSpinner.stop('Created initial commit');
+      } catch (err) {
+        commitSpinner.stop('Failed to create initial commit');
+        const errMsg = err.toString();
+        if (errMsg.includes('Author identity unknown') || errMsg.includes('unable to auto-detect email')) {
+          clack.log.error(
+            'Git identity not configured. Run:\n' +
+            '  git config --global user.email "you@example.com"\n' +
+            '  git config --global user.name "Your Name"'
+          );
+          process.exit(1);
+        }
+        throw err;
+      }
     }
 
     // Ask for project name

--- a/setup/setup.mjs
+++ b/setup/setup.mjs
@@ -152,7 +152,15 @@ async function main() {
       execSync(`git config --global user.name "${ghUser.name || ghUser.login}"`, { stdio: 'ignore' });
       execSync(`git config --global user.email "${ghUser.login}@users.noreply.github.com"`, { stdio: 'ignore' });
       clack.log.success('Git identity set from GitHub');
-    } catch {}
+    } catch {
+      clack.log.error(
+        'Could not set git identity automatically. Git requires your name and email to make commits.\n' +
+        'Please run the following commands and re-run setup:\n\n' +
+        '  git config --global user.name "Your Name"\n' +
+        '  git config --global user.email "you@example.com"'
+      );
+      process.exit(1);
+    }
   }
 
   if (prereqs.git.remoteInfo) {


### PR DESCRIPTION
Fixes #178

## Changes
- Updated git identity check to verify both `user.name` AND `user.email` (previously only checked `user.name`)
- Wrapped `git commit` call in try-catch to detect identity errors
- Added clear, actionable error message when git identity is not configured

## Why This Fix Matters
Previously, if a user had `user.name` configured but was missing `user.email`, the setup would silently fail during `git commit` with no helpful guidance. Now users get clear instructions on how to fix the issue.