### PR TITLE
fix: set world-writable permissions on cluster log dir and files (#203)

### DIFF
--- a/lib/cluster/execute.js
+++ b/lib/cluster/execute.js
@@ -243,12 +243,17 @@ export async function runClusterRole(roleData, payload, trigger) {
   const logDir = path.join(dataDir, logRelPath);
   env.push(`LOG_DIR=${logRelPath}`);
   fs.mkdirSync(logDir, { recursive: true });
+  fs.chmodSync(logDir, 0o777);
   fs.writeFileSync(path.join(logDir, 'system-prompt.md'), systemPrompt || '', 'utf8');
+  fs.chmodSync(path.join(logDir, 'system-prompt.md'), 0o666);
   fs.writeFileSync(path.join(logDir, 'user-prompt.md'), prompt || '', 'utf8');
+  fs.chmodSync(path.join(logDir, 'user-prompt.md'), 0o666);
   fs.writeFileSync(path.join(logDir, 'meta.json'), JSON.stringify({ roleName: roleData.roleName || 'Role', startedAt: new Date().toISOString() }), 'utf8');
+  fs.chmodSync(path.join(logDir, 'meta.json'), 0o666);
   if (trigger) {
     const triggerLog = JSON.stringify({ ...trigger, ...(payload ? { payload } : {}) }, null, 2);
     fs.writeFileSync(path.join(logDir, 'trigger.json'), triggerLog, 'utf8');
+    fs.chmodSync(path.join(logDir, 'trigger.json'), 0o666);
   }
 
   console.log(`[cluster] Launching role ${roleData.roleName} (${containerName})${payload ? ` payload=${JSON.stringify(payload)}` : ''}`);


### PR DESCRIPTION
## Root Cause
The cluster worker container runs as the `claude-code` user, while the host process (in `lib/cluster/execute.js`) runs as `root`. When the root process creates the log directory and writes initial files (`system-prompt.md`, `user-prompt.md`, `meta.json`, `trigger.json`), they are created with restrictive permissions that prevent the worker container from:
- Creating new files in the log directory (`stdout.jsonl`, `stderr.txt`)
- Updating existing files (`meta.json`)

## Solution
Added `fs.chmodSync()` calls to make files and directories world-writable:
1. After `fs.mkdirSync(logDir, { recursive: true })` → add `fs.chmodSync(logDir, 0o777)`
2. After each `fs.writeFileSync()` for log files → add corresponding `fs.chmodSync(filePath, 0o666)`

This allows the worker container to read, write, and update all log files without permission errors.

## Changed Files
- `lib/cluster/execute.js`: Added 5 `chmodSync` calls

## Testing
- Syntax check: `node --check lib/cluster/execute.js` ✓
- Changes are minimal and isolated to log file permissions only