### PR TITLE
fix: use correct --model flag for pi coding agent

### DIFF
--- a/docker/coding-agent/scripts/agents/pi-coding-agent/run.sh
+++ b/docker/coding-agent/scripts/agents/pi-coding-agent/run.sh
@@ -6,7 +6,7 @@
 PI_ARGS=(-p "$PROMPT" --mode json)
 
 if [ -n "$LLM_MODEL" ]; then
-    PI_ARGS+=(-m "$LLM_MODEL")
+    PI_ARGS+=(--model "$LLM_MODEL")
 fi
 
 if [ -n "$CUSTOM_OPENAI_BASE_URL" ]; then


### PR DESCRIPTION
## Description
This PR fixes a bug in the Pi coding agent's startup script that causes it to crash immediately when an `LLM_MODEL` override is provided. 

**What changed:**
Changed the `-m` flag to `--model` in `docker/coding-agent/scripts/agents/pi-coding-agent/run.sh`.

**Why:**
The `pi` CLI does not recognize the `-m` shorthand. When a headless task or cluster worker runs with a specific model configured, the script previously passed `(-m "$LLM_MODEL")`, which resulted in a fatal `Error: Unknown option: -m` crash. The interactive script (`interactive.sh`) already correctly uses `--model`, so this brings `run.sh` into alignment.

## Type of Change
- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Documentation update (`docs:`)
- [ ] Refactoring (`refactor:`)

## Testing
Verified that `pi` successfully accepts the `--model` flag without throwing an unknown option error, allowing the container to proceed with execution.