### PR TITLE
Fix Codex ChatGPT OAuth auth handling

### DIFF
--- a/docker/coding-agent/CLAUDE.md
+++ b/docker/coding-agent/CLAUDE.md
@@ -94,7 +94,7 @@ Called before any agent interaction. Set up credentials so the agent can authent
 Examples:
 - **claude-code**: Unsets `ANTHROPIC_API_KEY` when using OAuth so Claude Code uses the OAuth token instead
 - **pi-coding-agent**: No-op — Pi reads API keys directly from standard env vars
-- **codex-cli**: Pipes `OPENAI_API_KEY` into `codex login --with-api-key`
+- **codex-cli**: Writes Codex ChatGPT OAuth `auth.json` when `CODEX_OAUTH_TOKEN` contains that payload, or pipes `OPENAI_API_KEY` into `codex login --with-api-key`
 
 #### `setup.sh` — Agent configuration
 

--- a/docker/coding-agent/scripts/agents/codex-cli/auth.sh
+++ b/docker/coding-agent/scripts/agents/codex-cli/auth.sh
@@ -2,7 +2,43 @@
 # Codex CLI auth — credentials cached in ~/.codex/auth.json
 # Codex does NOT read OPENAI_API_KEY from env, must use `codex login`
 if [ -n "$CODEX_OAUTH_TOKEN" ]; then
-    echo "$CODEX_OAUTH_TOKEN" | codex login --with-api-key
+    mkdir -p ~/.codex
+    if CODEX_AUTH_JSON=$(node <<'EOF'
+const raw = (process.env.CODEX_OAUTH_TOKEN || '').trim();
+let payload = raw;
+if (!payload.startsWith('{')) {
+  try {
+    payload = Buffer.from(payload, 'base64').toString('utf8').trim();
+  } catch {}
+}
+
+let auth;
+try {
+  auth = JSON.parse(payload);
+} catch {
+  console.error('CODEX_OAUTH_TOKEN must contain the full Codex auth.json payload');
+  process.exit(1);
+}
+
+if (auth.auth_mode === 'apikey' || auth.OPENAI_API_KEY) {
+  console.error('CODEX_OAUTH_TOKEN contains API-key auth, not ChatGPT OAuth');
+  process.exit(1);
+}
+
+const tokens = auth.tokens || {};
+if (!tokens.id_token || !tokens.access_token || !tokens.refresh_token || !auth.last_refresh) {
+  console.error('CODEX_OAUTH_TOKEN is missing auth.json token fields');
+  process.exit(1);
+}
+
+process.stdout.write(JSON.stringify({ ...auth, auth_mode: auth.auth_mode || 'chatgpt' }, null, 2));
+EOF
+    ); then
+        printf '%s\n' "$CODEX_AUTH_JSON" > ~/.codex/auth.json
+        chmod 600 ~/.codex/auth.json
+    else
+        exit 1
+    fi
 elif [ -n "$OPENAI_API_KEY" ]; then
     echo "$OPENAI_API_KEY" | codex login --with-api-key
 fi

--- a/docs/CODING_AGENTS.md
+++ b/docs/CODING_AGENTS.md
@@ -71,7 +71,13 @@ claude setup-token
 
 Token starts with `sk-ant-oat01-`. Add it in Admin > Event Handler > Coding Agents > Claude Code.
 
-**Codex OAuth**: Similar flow for OpenAI subscribers.
+**Codex OAuth**: OpenAI subscribers should sign in with ChatGPT using Codex locally:
+
+```bash
+codex login
+```
+
+Then add the contents of `~/.codex/auth.json` in Admin > Event Handler > LLMs > OpenAI > OAuth Tokens. The Codex container writes this payload to `~/.codex/auth.json`; a single access token is not enough.
 
 **Multi-token rotation**: You can add multiple OAuth tokens. The system uses LRU (least-recently-used) rotation — each container launch picks the token that hasn't been used the longest. This helps distribute usage across subscription accounts.
 

--- a/lib/chat/actions.js
+++ b/lib/chat/actions.js
@@ -278,7 +278,7 @@ export async function deleteApiKey(id) {
  * Create a new named OAuth token.
  * @param {string} tokenType - Token type slug (e.g. 'claudeCode')
  * @param {string} name - Human-readable name
- * @param {string} token - Raw OAuth token
+ * @param {string} token - Raw OAuth token or Codex auth.json payload
  * @returns {Promise<{ id: string, name: string, createdAt: number, lastUsedAt: null } | { error: string }>}
  */
 export async function createOAuthToken(tokenType, name, token) {
@@ -286,13 +286,50 @@ export async function createOAuthToken(tokenType, name, token) {
   try {
     const { createOAuthToken: dbCreate } = await import('../db/oauth-tokens.js');
     const { invalidateConfigCache } = await import('../config.js');
-    const result = dbCreate(tokenType, name || 'OAuth Token', token, user.id);
+    const normalizedToken = tokenType === 'codex' ? normalizeCodexAuthJson(token) : token;
+    const result = dbCreate(tokenType, name || 'OAuth Token', normalizedToken, user.id);
     invalidateConfigCache();
     return result;
   } catch (err) {
     console.error('Failed to create OAuth token:', err);
-    return { error: 'Failed to create OAuth token' };
+    return { error: err.message || 'Failed to create OAuth token' };
   }
+}
+
+function normalizeCodexAuthJson(rawToken) {
+  let payload = String(rawToken || '').trim();
+  if (!payload) {
+    throw new Error('Codex auth.json is required');
+  }
+
+  if (!payload.startsWith('{')) {
+    try {
+      payload = Buffer.from(payload, 'base64').toString('utf8').trim();
+    } catch {
+      // Fall through to the JSON parser for the user-facing validation error.
+    }
+  }
+
+  let auth;
+  try {
+    auth = JSON.parse(payload);
+  } catch {
+    throw new Error('Paste the full Codex auth.json contents, not a single token');
+  }
+
+  if (auth.auth_mode === 'apikey' || auth.OPENAI_API_KEY) {
+    throw new Error('This is an API key login. Use Codex ChatGPT OAuth auth.json instead');
+  }
+
+  const tokens = auth.tokens || {};
+  if (!tokens.id_token || !tokens.access_token || !tokens.refresh_token || !auth.last_refresh) {
+    throw new Error('Codex auth.json must include id_token, access_token, refresh_token, and last_refresh');
+  }
+
+  return JSON.stringify({
+    ...auth,
+    auth_mode: auth.auth_mode || 'chatgpt',
+  });
 }
 
 /**
@@ -1567,5 +1604,4 @@ export async function unlinkTelegramChannel() {
   unlink(user.id, 'telegram');
   return { ok: true };
 }
-
 

--- a/lib/chat/components/settings-chat-page.jsx
+++ b/lib/chat/components/settings-chat-page.jsx
@@ -393,7 +393,7 @@ function ProviderCard({ name, slug, credentials, credentialStatuses, onUpdateCre
   // OAuth token sections per provider
   const oauthSections = {
     anthropic: { tokenType: 'claudeCode', description: 'For Claude Code CLI containers (Pro/Max subscription)' },
-    openai: { tokenType: 'codex', description: 'For Codex CLI containers (ChatGPT Plus/Pro subscription)' },
+    openai: { tokenType: 'codex', description: 'For Codex CLI containers (ChatGPT Plus/Pro auth.json)' },
   };
   const oauth = oauthSections[slug];
 
@@ -496,6 +496,10 @@ function OAuthTokenList({ tokenType = 'claudeCode', description = 'For Claude Co
     setError(null);
   };
 
+  const isCodex = tokenType === 'codex';
+  const tokenLabel = isCodex ? 'Auth JSON' : 'Token';
+  const tokenPlaceholder = isCodex ? 'Paste ~/.codex/auth.json contents...' : 'Paste OAuth token...';
+
   if (loading) {
     return <div className="h-16 animate-pulse rounded-md bg-border/50" />;
   }
@@ -532,15 +536,27 @@ function OAuthTokenList({ tokenType = 'claudeCode', description = 'For Claude Co
               />
             </div>
             <div>
-              <label className="text-xs font-medium mb-1 block">Token</label>
-              <input
-                type="password"
-                value={newToken}
-                onChange={(e) => setNewToken(e.target.value)}
-                placeholder="Paste OAuth token..."
-                className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-foreground"
-                onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
-              />
+              <label className="text-xs font-medium mb-1 block">{tokenLabel}</label>
+              {isCodex ? (
+                <textarea
+                  value={newToken}
+                  onChange={(e) => setNewToken(e.target.value)}
+                  placeholder={tokenPlaceholder}
+                  rows={5}
+                  spellCheck={false}
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-foreground resize-y"
+                  onKeyDown={(e) => (e.metaKey || e.ctrlKey) && e.key === 'Enter' && handleCreate()}
+                />
+              ) : (
+                <input
+                  type="password"
+                  value={newToken}
+                  onChange={(e) => setNewToken(e.target.value)}
+                  placeholder={tokenPlaceholder}
+                  className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-foreground"
+                  onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+                />
+              )}
             </div>
           </div>
           <div className="mt-5 flex justify-end gap-2">

--- a/lib/tools/CLAUDE.md
+++ b/lib/tools/CLAUDE.md
@@ -19,7 +19,7 @@ Per-agent resolution paths:
 - **`claude-code`** — `CODING_AGENT_CLAUDE_CODE_BACKEND` selects backend. If `anthropic`, picks OAuth (`CLAUDE_CODE_OAUTH_TOKEN` via LRU rotation) or API key (`ANTHROPIC_API_KEY`). For Anthropic-compatible third parties (DeepSeek, MiniMax, Kimi, OpenRouter) sets `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL` to the provider's `anthropicEndpoint`. For OpenAI-only builtins or custom providers, routes through the LiteLLM sidecar at `http://litellm:4000` and prefixes the model with the provider key.
 - **`pi-coding-agent`, `opencode`, `kimi-cli`** — share a multi-provider pattern. `CODING_AGENT_{AGENT}_PROVIDER` picks anthropic/openai/google/deepseek/minimax/mistral/xai/openrouter/nvidia or a custom provider. Sets the matching `*_API_KEY` (or `CUSTOM_OPENAI_BASE_URL` + `CUSTOM_API_KEY` for custom).
 - **`gemini-cli`** — `GOOGLE_API_KEY` only. Backend is always `google`.
-- **`codex-cli`** — OAuth (`CODEX_OAUTH_TOKEN`) or API key (`OPENAI_API_KEY`). Backend always `openai`.
+- **`codex-cli`** — ChatGPT OAuth (`CODEX_OAUTH_TOKEN`, containing Codex `auth.json`) or API key (`OPENAI_API_KEY`). Backend always `openai`.
 
 OAuth tokens use LRU rotation via `getNextOAuthToken()` (in `lib/db/oauth-tokens.js`) — distributes load across multiple stored tokens and updates `lastUsedAt` on each pick. Refresh-token rotation is handled at retrieval time in `/api/get-agent-job-secret` (under a per-token lock).
 


### PR DESCRIPTION
## Summary
- Treat Codex OAuth entries as full Codex auth.json payloads instead of single API-key-style tokens
- Write Codex ChatGPT OAuth payloads to ~/.codex/auth.json inside Codex containers
- Update the OpenAI OAuth modal and docs to ask for Codex auth.json contents

## Verification
- Validated Codex auth script writes auth.json for a ChatGPT OAuth payload
- Validated API-key auth JSON is rejected in Codex OAuth mode
- Ran bash -n docker/coding-agent/scripts/agents/codex-cli/auth.sh
- Ran git diff --check
- Ran npm run build
- Ran npm test