### PR TITLE
Add white-label branding via env vars + runtime asset directory

### DIFF
--- a/docker/event-handler/Dockerfile
+++ b/docker/event-handler/Dockerfile
@@ -14,10 +14,20 @@ RUN apt-get update && \
 
 WORKDIR /app
 COPY package.json package-lock.json* ./
+# Dev override: if a local tarball (`npm pack`) was copied alongside, install
+# from it instead of the npm registry. Lets contributors bake working-tree
+# changes into the image without publishing. Falls back to npm when absent.
+COPY thepopebot-*.tgz* ./
 # Rename package to avoid npm treating "thepopebot" as a self-install
 RUN TPB_VERSION=$(node -p "require('./package.json').version") && \
     echo "{\"private\":true}" > package.json && \
-    npm install --no-save "thepopebot@${TPB_VERSION}" tailwindcss @tailwindcss/postcss
+    TARBALL=$(ls thepopebot-*.tgz 2>/dev/null | head -1) && \
+    if [ -n "$TARBALL" ]; then \
+      echo "[dev] Installing local tarball: $TARBALL" && \
+      npm install --no-save "./${TARBALL}" tailwindcss @tailwindcss/postcss; \
+    else \
+      npm install --no-save "thepopebot@${TPB_VERSION}" tailwindcss @tailwindcss/postcss; \
+    fi
 
 # ── Stage 2: Next.js build ───────────────────────────────────────
 FROM node:22-bookworm-slim AS nextjs

--- a/lib/auth/components/ascii-logo.js
+++ b/lib/auth/components/ascii-logo.js
@@ -1,11 +1,25 @@
+"use client";
 import { jsx } from "react/jsx-runtime";
-function AsciiLogo() {
-  return /* @__PURE__ */ jsx("pre", { className: "text-foreground text-[clamp(0.45rem,1.5vw,0.85rem)] leading-snug text-left mb-8 select-none", children: ` _____ _          ____                  ____        _
+import { useBranding } from "thepopebot/branding/provider";
+const DEFAULT_ASCII = ` _____ _          ____                  ____        _
 |_   _| |__   ___|  _ \\ ___  _ __   ___| __ )  ___ | |_
   | | | '_ \\ / _ \\ |_) / _ \\| '_ \\ / _ \\  _ \\ / _ \\| __|
   | | | | | |  __/  __/ (_) | |_) |  __/ |_) | (_) | |_
   |_| |_| |_|\\___|_|   \\___/| .__/ \\___|____/ \\___/ \\__|
-                            |_|` });
+                            |_|`;
+function AsciiLogo() {
+  const { hasCustomLogo, productName } = useBranding();
+  if (hasCustomLogo) {
+    return /* @__PURE__ */ jsx(
+      "img",
+      {
+        src: "/branding/logo",
+        alt: productName,
+        className: "mb-8 max-h-24 w-auto select-none"
+      }
+    );
+  }
+  return /* @__PURE__ */ jsx("pre", { className: "text-foreground text-[clamp(0.45rem,1.5vw,0.85rem)] leading-snug text-left mb-8 select-none", children: DEFAULT_ASCII });
 }
 export {
   AsciiLogo

--- a/lib/auth/components/ascii-logo.jsx
+++ b/lib/auth/components/ascii-logo.jsx
@@ -1,10 +1,30 @@
-export function AsciiLogo() {
-  return (
-    <pre className="text-foreground text-[clamp(0.45rem,1.5vw,0.85rem)] leading-snug text-left mb-8 select-none">{` _____ _          ____                  ____        _
+'use client';
+
+import { useBranding } from 'thepopebot/branding/provider';
+
+const DEFAULT_ASCII = ` _____ _          ____                  ____        _
 |_   _| |__   ___|  _ \\ ___  _ __   ___| __ )  ___ | |_
   | | | '_ \\ / _ \\ |_) / _ \\| '_ \\ / _ \\  _ \\ / _ \\| __|
   | | | | | |  __/  __/ (_) | |_) |  __/ |_) | (_) | |_
   |_| |_| |_|\\___|_|   \\___/| .__/ \\___|____/ \\___/ \\__|
-                            |_|`}</pre>
+                            |_|`;
+
+export function AsciiLogo() {
+  const { hasCustomLogo, productName } = useBranding();
+
+  if (hasCustomLogo) {
+    return (
+      <img
+        src="/branding/logo"
+        alt={productName}
+        className="mb-8 max-h-24 w-auto select-none"
+      />
+    );
+  }
+
+  return (
+    <pre className="text-foreground text-[clamp(0.45rem,1.5vw,0.85rem)] leading-snug text-left mb-8 select-none">
+      {DEFAULT_ASCII}
+    </pre>
   );
 }

--- a/lib/auth/components/login-form.js
+++ b/lib/auth/components/login-form.js
@@ -7,9 +7,11 @@ import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "./ui/card";
+import { useBranding } from "thepopebot/branding/provider";
 function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { productTagline } = useBranding();
   const justCreated = searchParams.get("created") === "1";
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -41,7 +43,7 @@ function LoginForm() {
     /* @__PURE__ */ jsxs(Card, { className: "w-full max-w-sm", children: [
       /* @__PURE__ */ jsxs(CardHeader, { children: [
         /* @__PURE__ */ jsx(CardTitle, { children: "Sign In" }),
-        /* @__PURE__ */ jsx(CardDescription, { children: "Log in to your agent dashboard." })
+        /* @__PURE__ */ jsx(CardDescription, { children: productTagline })
       ] }),
       /* @__PURE__ */ jsx(CardContent, { children: /* @__PURE__ */ jsxs("form", { onSubmit: handleSubmit, className: "space-y-4", children: [
         /* @__PURE__ */ jsxs("div", { className: "space-y-2", children: [

--- a/lib/auth/components/login-form.jsx
+++ b/lib/auth/components/login-form.jsx
@@ -7,10 +7,12 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from './ui/card';
+import { useBranding } from 'thepopebot/branding/provider';
 
 export function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { productTagline } = useBranding();
   const justCreated = searchParams.get('created') === '1';
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -53,7 +55,7 @@ export function LoginForm() {
     <Card className="w-full max-w-sm">
       <CardHeader>
         <CardTitle>Sign In</CardTitle>
-        <CardDescription>Log in to your agent dashboard.</CardDescription>
+        <CardDescription>{productTagline}</CardDescription>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/lib/auth/components/setup-form.js
+++ b/lib/auth/components/setup-form.js
@@ -7,8 +7,10 @@ import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "./ui/card";
 import { setupAdmin } from "../actions.js";
+import { useBranding } from "thepopebot/branding/provider";
 function SetupForm() {
   const router = useRouter();
+  const { setupTagline } = useBranding();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -83,7 +85,7 @@ function SetupForm() {
   return /* @__PURE__ */ jsxs(Card, { className: "w-full max-w-sm", children: [
     /* @__PURE__ */ jsxs(CardHeader, { children: [
       /* @__PURE__ */ jsx(CardTitle, { children: "Create Admin Account" }),
-      /* @__PURE__ */ jsx(CardDescription, { children: "Set up your first admin account to get started." })
+      /* @__PURE__ */ jsx(CardDescription, { children: setupTagline })
     ] }),
     /* @__PURE__ */ jsx(CardContent, { children: /* @__PURE__ */ jsxs("form", { onSubmit: handleSubmit, className: "space-y-4", children: [
       /* @__PURE__ */ jsxs("div", { className: "space-y-2", children: [

--- a/lib/auth/components/setup-form.jsx
+++ b/lib/auth/components/setup-form.jsx
@@ -7,9 +7,11 @@ import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from './ui/card';
 import { setupAdmin } from '../actions.js';
+import { useBranding } from 'thepopebot/branding/provider';
 
 export function SetupForm() {
   const router = useRouter();
+  const { setupTagline } = useBranding();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -97,7 +99,7 @@ export function SetupForm() {
     <Card className="w-full max-w-sm">
       <CardHeader>
         <CardTitle>Create Admin Account</CardTitle>
-        <CardDescription>Set up your first admin account to get started.</CardDescription>
+        <CardDescription>{setupTagline}</CardDescription>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/lib/auth/middleware.js
+++ b/lib/auth/middleware.js
@@ -10,6 +10,10 @@ export const middleware = auth((req) => {
   // API routes use their own centralized auth (checkAuth in api/index.js)
   if (pathname.startsWith('/api')) return;
 
+  // Branding assets (logo, favicon) — public, no auth required so they
+  // render on the login page itself.
+  if (pathname.startsWith('/branding/')) return;
+
   // Static assets from public/ — skip auth for common file extensions
   if (/\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|woff2?|ttf|eot|mp4|webm)$/i.test(pathname)) {
     return;

--- a/lib/branding/config.js
+++ b/lib/branding/config.js
@@ -1,0 +1,87 @@
+/**
+ * Branding configuration — read at request time from env vars and the filesystem.
+ *
+ * All values are optional. When unset, defaults preserve the existing ThePopeBot
+ * look so this is a backwards-compatible additive change.
+ *
+ * Server-side only. Client components receive these values via BrandingProvider.
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const DEFAULTS = {
+  productName: 'ThePopeBot',
+  productTagline: 'Log in to your agent dashboard.',
+  setupTagline: 'Set up your first admin account to get started.',
+  attributionText: '',
+  attributionUrl: '',
+};
+
+const BRANDING_DIR = process.env.BRANDING_DIR || '/app/branding';
+
+/**
+ * @returns {{
+ *   productName: string,
+ *   productTagline: string,
+ *   setupTagline: string,
+ *   attributionText: string,
+ *   attributionUrl: string,
+ *   hasCustomLogo: boolean,
+ *   hasCustomFavicon: boolean,
+ *   brandingDir: string,
+ * }}
+ */
+export function getBranding() {
+  return {
+    productName: process.env.PRODUCT_NAME || DEFAULTS.productName,
+    productTagline: process.env.PRODUCT_TAGLINE || DEFAULTS.productTagline,
+    setupTagline: process.env.SETUP_TAGLINE || DEFAULTS.setupTagline,
+    attributionText: process.env.ATTRIBUTION_TEXT || DEFAULTS.attributionText,
+    attributionUrl: process.env.ATTRIBUTION_URL || DEFAULTS.attributionUrl,
+    hasCustomLogo: hasLogoFile(),
+    hasCustomFavicon: hasFaviconFile(),
+    brandingDir: BRANDING_DIR,
+  };
+}
+
+function hasLogoFile() {
+  return (
+    existsSync(join(BRANDING_DIR, 'logo.svg')) ||
+    existsSync(join(BRANDING_DIR, 'logo.png')) ||
+    existsSync(join(BRANDING_DIR, 'logo.jpg'))
+  );
+}
+
+function hasFaviconFile() {
+  return (
+    existsSync(join(BRANDING_DIR, 'favicon.svg')) ||
+    existsSync(join(BRANDING_DIR, 'favicon.ico')) ||
+    existsSync(join(BRANDING_DIR, 'favicon.png'))
+  );
+}
+
+/**
+ * Resolve the actual filename for the logo (returns the first extension that exists).
+ * Used by the /branding/[asset] route to find the right file.
+ * @param {string} asset - e.g. 'logo' or 'favicon'
+ * @returns {string|null} - absolute path, or null if no matching file
+ */
+export function resolveBrandingAsset(asset) {
+  const safe = String(asset || '').replace(/[^a-z0-9.-]/gi, '');
+  if (!safe || safe.startsWith('.') || safe.includes('..')) return null;
+
+  // If extension is explicit (e.g. 'logo.svg'), serve that exact file
+  if (safe.includes('.')) {
+    const path = join(BRANDING_DIR, safe);
+    return existsSync(path) ? path : null;
+  }
+
+  // No extension: try common ones in priority order
+  const extensions = ['svg', 'png', 'ico', 'jpg', 'jpeg'];
+  for (const ext of extensions) {
+    const path = join(BRANDING_DIR, `${safe}.${ext}`);
+    if (existsSync(path)) return path;
+  }
+  return null;
+}

--- a/lib/branding/provider.js
+++ b/lib/branding/provider.js
@@ -1,0 +1,22 @@
+"use client";
+import { jsx } from "react/jsx-runtime";
+import { createContext, useContext } from "react";
+const BrandingContext = createContext({
+  productName: "ThePopeBot",
+  productTagline: "Log in to your agent dashboard.",
+  setupTagline: "Set up your first admin account to get started.",
+  attributionText: "",
+  attributionUrl: "",
+  hasCustomLogo: false,
+  hasCustomFavicon: false
+});
+function BrandingProvider({ value, children }) {
+  return /* @__PURE__ */ jsx(BrandingContext.Provider, { value, children });
+}
+function useBranding() {
+  return useContext(BrandingContext);
+}
+export {
+  BrandingProvider,
+  useBranding
+};

--- a/lib/branding/provider.jsx
+++ b/lib/branding/provider.jsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+const BrandingContext = createContext({
+  productName: 'ThePopeBot',
+  productTagline: 'Log in to your agent dashboard.',
+  setupTagline: 'Set up your first admin account to get started.',
+  attributionText: '',
+  attributionUrl: '',
+  hasCustomLogo: false,
+  hasCustomFavicon: false,
+});
+
+/**
+ * Wraps the app and provides branding values to all client components.
+ * Initial values are computed server-side and passed in.
+ */
+export function BrandingProvider({ value, children }) {
+  return (
+    <BrandingContext.Provider value={value}>{children}</BrandingContext.Provider>
+  );
+}
+
+/**
+ * Hook to access branding values from any client component.
+ */
+export function useBranding() {
+  return useContext(BrandingContext);
+}

--- a/lib/chat/components/app-sidebar.jsx
+++ b/lib/chat/components/app-sidebar.jsx
@@ -5,6 +5,7 @@ import { CirclePlusIcon, PanelLeftIcon, MessageIcon, ClusterIcon, BellIcon, Cont
 import { SidebarHistory } from './sidebar-history.js';
 import { SidebarUserNav } from './sidebar-user-nav.js';
 import { UpgradeDialog } from './upgrade-dialog.js';
+import { AttributionFooter } from './attribution-footer.js';
 import {
   Sidebar,
   SidebarContent,
@@ -17,10 +18,12 @@ import {
 } from './ui/sidebar.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
 import { useChatNav } from './chat-nav-context.js';
+import { useBranding } from 'thepopebot/branding/provider';
 
 export function AppSidebar({ user }) {
   const { navigateToChat } = useChatNav();
   const { state, open, setOpenMobile, toggleSidebar } = useSidebar();
+  const { productName } = useBranding();
   const collapsed = state === 'collapsed';
   const [unreadCount, setUnreadCount] = useState(0);
   const [prCount, setPrCount] = useState(0);
@@ -64,7 +67,7 @@ export function AppSidebar({ user }) {
         {/* Top row: brand name + toggle icon (open) or just toggle icon (collapsed) */}
         <div className={collapsed ? 'flex justify-center' : 'flex items-center justify-between'}>
           {!collapsed && (
-            <span className="px-2 font-semibold text-lg">ThePopeBot{version && <span className="text-[11px] font-normal text-muted-foreground"> v{version}</span>}</span>
+            <span className="px-2 font-semibold text-lg">{productName}{version && <span className="text-[11px] font-normal text-muted-foreground"> v{version}</span>}</span>
           )}
           <button
             className="inline-flex shrink-0 items-center justify-center rounded-md p-2 text-muted-foreground hover:bg-background hover:text-foreground"
@@ -287,6 +290,7 @@ export function AppSidebar({ user }) {
 
       <SidebarFooter>
         {user && <SidebarUserNav user={user} collapsed={collapsed} />}
+        <AttributionFooter collapsed={collapsed} />
       </SidebarFooter>
     </Sidebar>
     <UpgradeDialog open={upgradeOpen} onClose={() => setUpgradeOpen(false)} version={version} updateAvailable={updateAvailable} changelog={changelog} />

--- a/lib/chat/components/attribution-footer.jsx
+++ b/lib/chat/components/attribution-footer.jsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useBranding } from 'thepopebot/branding/provider';
+
+/**
+ * Small "powered by" / attribution footer for the sidebar.
+ * Renders nothing if ATTRIBUTION_TEXT is unset.
+ *
+ * @param {{ collapsed?: boolean }} props
+ */
+export function AttributionFooter({ collapsed }) {
+  const { attributionText, attributionUrl } = useBranding();
+
+  if (!attributionText || collapsed) return null;
+
+  const content = (
+    <span className="text-[10px] text-muted-foreground/70 leading-snug select-none">
+      {attributionText}
+    </span>
+  );
+
+  if (attributionUrl) {
+    return (
+      <div className="px-2 pb-1 pt-2">
+        <a
+          href={attributionUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-muted-foreground transition-colors"
+        >
+          {content}
+        </a>
+      </div>
+    );
+  }
+
+  return <div className="px-2 pb-1 pt-2">{content}</div>;
+}

--- a/lib/chat/components/chat-header.jsx
+++ b/lib/chat/components/chat-header.jsx
@@ -8,8 +8,10 @@ import { RenameDialog } from './ui/rename-dialog.jsx';
 import { ChevronDownIcon, StarIcon, StarFilledIcon, PencilIcon, TrashIcon, AgentIcon, CodeIcon } from './icons.js';
 import { renameChat, deleteChat, starChat } from '../actions.js';
 import { useChatNav } from './chat-nav-context.js';
+import { useBranding } from 'thepopebot/branding/provider';
 
 export function ChatHeader({ chatId: chatIdProp, workspaceId }) {
+  const { productName } = useBranding();
   const [title, setTitle] = useState(null);
   const [starred, setStarred] = useState(0);
   const [resolvedChatId, setResolvedChatId] = useState(chatIdProp || null);
@@ -77,9 +79,9 @@ export function ChatHeader({ chatId: chatIdProp, workspaceId }) {
     return () => {
       window.removeEventListener('chatTitleUpdated', titleHandler);
       window.removeEventListener('chatStarUpdated', starHandler);
-      document.title = 'ThePopeBot';
+      document.title = productName;
     };
-  }, [fetchMeta, chatId]);
+  }, [fetchMeta, chatId, productName]);
 
   // Auto-focus and select all when entering inline edit mode
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "./oauth": "./lib/oauth/helper.js",
     "./oauth/providers": "./lib/oauth/providers.js",
     "./maintenance": "./lib/maintenance.js",
+    "./branding/config": "./lib/branding/config.js",
+    "./branding/provider": "./lib/branding/provider.js",
     "./package.json": "./package.json"
   },
   "files": [
@@ -48,7 +50,7 @@
     "drizzle/"
   ],
   "scripts": {
-    "build": "esbuild lib/chat/components/*.jsx lib/chat/components/**/*.jsx --outdir=lib/chat/components --format=esm --jsx=automatic --outbase=lib/chat/components && esbuild lib/auth/components/*.jsx lib/auth/components/**/*.jsx --outdir=lib/auth/components --format=esm --jsx=automatic --outbase=lib/auth/components && esbuild lib/code/*.jsx --outdir=lib/code --format=esm --jsx=automatic && esbuild lib/cluster/components/*.jsx --outdir=lib/cluster/components --format=esm --jsx=automatic",
+    "build": "esbuild lib/chat/components/*.jsx lib/chat/components/**/*.jsx --outdir=lib/chat/components --format=esm --jsx=automatic --outbase=lib/chat/components && esbuild lib/auth/components/*.jsx lib/auth/components/**/*.jsx --outdir=lib/auth/components --format=esm --jsx=automatic --outbase=lib/auth/components && esbuild lib/branding/*.jsx --outdir=lib/branding --format=esm --jsx=automatic && esbuild lib/code/*.jsx --outdir=lib/code --format=esm --jsx=automatic && esbuild lib/cluster/components/*.jsx --outdir=lib/cluster/components --format=esm --jsx=automatic",
     "prepublishOnly": "npm run build",
     "postinstall": "node -e \"import('./bin/postinstall.js').catch(()=>{})\"",
     "db:generate": "drizzle-kit generate",

--- a/templates/.env.example
+++ b/templates/.env.example
@@ -60,3 +60,23 @@ ASSEMBLYAI_API_KEY=
 # Custom Docker images (optional, overrides the default stephengpope/thepopebot images)
 # EVENT_HANDLER_IMAGE_URL=
 # JOB_IMAGE_URL=
+
+# ── White-label branding (all optional) ─────────────────────────────
+# Display name shown in browser tab, sidebar header, etc. (default: ThePopeBot)
+# PRODUCT_NAME=
+
+# Card description on the sign-in page (default: "Log in to your agent dashboard.")
+# PRODUCT_TAGLINE=
+
+# Card description on the first-user setup page
+# SETUP_TAGLINE=
+
+# Footer attribution text in the sidebar (e.g. "An AutomationEdge product"). Hidden if empty.
+# ATTRIBUTION_TEXT=
+
+# Optional URL the attribution text links to
+# ATTRIBUTION_URL=
+
+# Directory inside the container holding logo.svg / favicon.svg / etc.
+# Mount your assets here via docker-compose volume (default: /app/branding)
+# BRANDING_DIR=/app/branding

--- a/web/app/branding/[asset]/route.js
+++ b/web/app/branding/[asset]/route.js
@@ -1,0 +1,43 @@
+import { readFile } from 'fs/promises';
+import { extname } from 'path';
+import { resolveBrandingAsset } from 'thepopebot/branding/config';
+
+const CONTENT_TYPES = {
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.css': 'text/css',
+};
+
+/**
+ * GET /branding/:asset
+ *
+ * Serves files from the BRANDING_DIR (default /app/branding). Used to deliver
+ * the install's custom logo, favicon, and CSS overrides without baking them
+ * into the upstream image.
+ *
+ * Path traversal is prevented: only basenames matching [a-z0-9.-]+ are accepted.
+ */
+export async function GET(request, { params }) {
+  const { asset } = await params;
+  const resolved = resolveBrandingAsset(asset);
+  if (!resolved) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  try {
+    const data = await readFile(resolved);
+    const contentType = CONTENT_TYPES[extname(resolved).toLowerCase()] || 'application/octet-stream';
+    return new Response(data, {
+      status: 200,
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=3600',
+      },
+    });
+  } catch {
+    return new Response('Not found', { status: 404 });
+  }
+}

--- a/web/app/layout.js
+++ b/web/app/layout.js
@@ -1,10 +1,18 @@
 import './globals.css';
 import { ThemeProvider } from 'thepopebot/chat';
+import { BrandingProvider } from 'thepopebot/branding/provider';
+import { getBranding } from 'thepopebot/branding/config';
 
-export const metadata = {
-  title: 'ThePopeBot',
-  description: 'AI Agent',
-};
+export function generateMetadata() {
+  const { productName, hasCustomFavicon } = getBranding();
+  return {
+    title: productName,
+    description: 'AI Agent',
+    ...(hasCustomFavicon
+      ? { icons: { icon: '/branding/favicon' } }
+      : {}),
+  };
+}
 
 export const viewport = {
   width: 'device-width',
@@ -14,12 +22,13 @@ export const viewport = {
 };
 
 export default function RootLayout({ children }) {
+  const branding = getBranding();
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="min-h-svh bg-background text-foreground antialiased">
-        <ThemeProvider>
-          {children}
-        </ThemeProvider>
+        <BrandingProvider value={branding}>
+          <ThemeProvider>{children}</ThemeProvider>
+        </BrandingProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

Make all "ThePopeBot"-branded UI surfaces (browser tab, sidebar header, login/setup page logo, favicon, footer) driven by env vars + a runtime asset directory, with sensible defaults that preserve existing behavior when nothing is configured.

Per-install white-label without an image rebuild. Each operator can ship their own product name, logo, favicon, and optional "powered by" attribution by setting env vars and mounting a branding directory.

Live tested in production on a DigitalOcean droplet — see screenshots / verification below.

## Why

I'm shipping thepopebot to accounting firms and each firm needs their own brand on the UI. Cloud-baked images that are common across firms with per-install branding via env + volume mount is the lowest-friction model. Posting this upstream because every popebot user has the same problem the moment they want to put thepopebot in front of clients.

## What's included

### New env vars (all optional, defaults preserve current behavior)

| Var | Used for | Default |
|---|---|---|
| \`PRODUCT_NAME\` | Browser tab title, sidebar header, document.title fallback | \`ThePopeBot\` |
| \`PRODUCT_TAGLINE\` | Login card description | \`Log in to your agent dashboard.\` |
| \`SETUP_TAGLINE\` | First-user setup card description | \`Set up your first admin account to get started.\` |
| \`ATTRIBUTION_TEXT\` | Sidebar footer attribution text | *(empty — footer hidden)* |
| \`ATTRIBUTION_URL\` | Optional link wrapping the attribution | *(empty)* |
| \`BRANDING_DIR\` | Directory holding logo/favicon files | \`/app/branding\` |

### Runtime asset directory

The \`BRANDING_DIR\` (default \`/app/branding\`) is read at request time. Drop in:

| File | Replaces |
|---|---|
| \`logo.{svg,png,jpg}\` | ASCII logo on login/setup pages → renders as \`<img>\` |
| \`favicon.{svg,ico,png}\` | Default robot favicon via Next.js metadata override |

Served via the new \`/branding/[asset]\` route with path-traversal protection and correct Content-Type. Public route (whitelisted in middleware) so the logo can render on the login page itself.

### New modules

- \`lib/branding/config.js\` — server-side env + filesystem reader
- \`lib/branding/provider.jsx\` — client-side React Context + \`useBranding()\` hook (matches existing \`ThemeProvider\` pattern)
- \`lib/chat/components/attribution-footer.jsx\` — sidebar footer
- \`web/app/branding/[asset]/route.js\` — file server for \`BRANDING_DIR\`

### UI surfaces wired

| File | Change |
|---|---|
| \`web/app/layout.js\` | \`generateMetadata\` reads \`PRODUCT_NAME\` + sets favicon override when custom favicon present |
| \`lib/chat/components/app-sidebar.jsx\` | Sidebar header reads \`PRODUCT_NAME\`; adds \`<AttributionFooter />\` |
| \`lib/chat/components/chat-header.jsx\` | \`document.title\` fallback reads \`PRODUCT_NAME\` |
| \`lib/auth/components/ascii-logo.jsx\` | Renders \`<img>\` if logo file present, ASCII art otherwise |
| \`lib/auth/components/login-form.jsx\` | Card description reads \`PRODUCT_TAGLINE\` |
| \`lib/auth/components/setup-form.jsx\` | Card description reads \`SETUP_TAGLINE\` |
| \`lib/auth/middleware.js\` | Whitelist \`/branding/*\` as public |
| \`docker/event-handler/Dockerfile\` | Dev-tarball install path for local-build testing |
| \`templates/.env.example\` | Document the new vars |
| \`package.json\` | New \`./branding/config\` + \`./branding/provider\` exports; \`lib/branding/*.jsx\` added to build |

## Compatibility

- **Zero breaking changes.** With no env vars set, the UI renders exactly as before: title "ThePopeBot", original ASCII logo, default robot favicon, no footer attribution.
- **No required new env vars** — bot boots cleanly without any branding config.
- **Backwards-compatible image:** existing installs upgrading to this version see no change unless they opt in.

## Live verification

Production install at \`jay.yourdigitalpractice.com\` (DigitalOcean droplet, Cloudflare wildcard SSL):

\`\`\`bash
\$ curl -s https://jay.yourdigitalpractice.com/login | grep -oE '<title>[^<]*</title>'
<title>Ledger</title>

\$ curl -sI https://jay.yourdigitalpractice.com/branding/logo
HTTP/2 200
content-type: image/svg+xml

\$ curl -sI https://jay.yourdigitalpractice.com/branding/favicon
HTTP/2 200
content-type: image/svg+xml
\`\`\`

Login page renders custom SVG logo in place of ASCII art. Sidebar shows "Ledger" with footer "An AutomationEdge product" linking out. Browser tab favicon swapped.

## Test plan

- [x] Defaults preserved when no env vars set (verified locally with empty branding config)
- [x] \`PRODUCT_NAME\` flows to tab title, sidebar header, \`document.title\` fallback
- [x] \`PRODUCT_TAGLINE\` / \`SETUP_TAGLINE\` flow to login/setup card descriptions
- [x] Custom \`logo.svg\` renders as \`<img>\` on login/setup pages
- [x] Custom \`favicon.svg\` swaps the browser tab icon
- [x] \`ATTRIBUTION_TEXT\` + \`ATTRIBUTION_URL\` render footer link in sidebar
- [x] \`/branding/[asset]\` route rejects path traversal (\`../etc/passwd\` returns 404)
- [x] Production deploy on Ubuntu 24.04 droplet, Cloudflare DNS challenge wildcard SSL

## Notes

- One Dockerfile change snuck in: dev-tarball install path (\`COPY thepopebot-*.tgz* ./\` + tarball-first conditional). Same change exists in PR #257; if #257 merges first this delta will resolve naturally on rebase.
- No new runtime library dependencies. \`lib/branding/*.jsx\` added to the esbuild build script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)